### PR TITLE
feat: use lerna to manage the monorepo

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,7 @@
+/artifacts
+/build
+/dist
+/node_modules
+**/artifacts
+**/build
+**/node_modules

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,55 @@
+<!-- Thank you so much for filing this issue! Please provide the detail about your problem! -->
+
+### Is this a BUG REPORT or FEATURE REQUEST? (choose one)
+<!--
+If this is a BUG REPORT, please:
+
+  - Fill in as much of the template below as you can. If you leave out information, we can't help you as well.
+
+If this is a FEATURE REQUEST, please:
+
+  - Describe **in detail** the feature/behavior/change you'd like to see.
+-->
+
+### Expected behavior
+<!-- Please describe the behavior you expected. -->
+
+### Current behavior
+<!-- Please describe what happens instead of your expected behavior. -->
+
+### Step to reproduce for BUG REPORT
+<!-- Please describe steps to reproduce this bug as minimally and precisely as possible.
+
+For example:
+- minimum live example (e.g. repl.it, jsbin.com )
+- minimum example code
+- set of steps to reproduce
+-->
+
+### Your Environment
+<!-- Please describe your environment information. -->
+<!-- Please describe your OS and browser information if your problem occurs on a specific OS or browser. -->
+
+| Executable | Version |
+| ---: | :--- |
+| `npm ls <package name>` | VERSION |
+| `npm --version` | VERSION |
+| `node --version` | VERSION |
+
+| OS | Version |
+| --- | --- |
+| NAME | VERSION |
+<!-- For example:
+| macOS Sierra | 10.14.4 |
+| Windows 10 | 1607 |
+| Ubuntu | 16.10 |
+-->
+
+| Browser | Version |
+| --- | --- |
+| NAME | VERSION |
+<!-- For example:
+| Chrome | 74.0.3729.131 |
+| Safari | 12.1 |
+| Firefox | 66.0 |
+-->

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+/artifacts
+/.nyc_output
+/coverage
+/dist
+/node_modules
+*.log
+*.tgz
+package-lock.json

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock = false

--- a/.nycrc
+++ b/.nycrc
@@ -1,0 +1,5 @@
+{
+  "reporter": "lcov",
+  "sourceMap": false,
+  "instrument": false
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo: false
+language: node_js
+node_js:
+  - 10
+  - 12
+before_script: npm run build
+script: npm test
+after_success:
+  - "npm run cover"
+  - "npm run cover:collect"
+  - "cat artifacts/coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+Contributing
+============
+
+Pull requests are very welcome, but should be within the scope of the project, and follow the repository's code conventions. Before submitting a pull request, it's always good to file an issue, so we can discuss the details of the PR.
+
+## Reporting a Bug
+
+1. Ensure you've replicated the issue against master.  There is a chance the issue may have already been fixed.
+
+2. Search for any similar issues (both opened and closed).  There is a chance someone may have reported it already.
+
+3. Provide a demo of the bug isolated in a jsfiddle/jsbin.  Sometimes this is not a possibility, in which case provide a detailed description along with any code snippets that would help in triaging the issue.  If we cannot reproduce it, we will close it.
+
+4. The best way to demonstrate a bug is to build a failing test.  This is not required, however, it will generally speed up the development process.
+
+## Submitting a pull request
+
+1. At Yahoo, we have a single [Yahoo Open Source Contributor License Agreement](https://yahoocla.herokuapp.com/) that we ask contributors to electronically sign before merging in their Pull Requests. Here's the CLA's human-readable summary:
+
+> You are saying that you have the right to give us this code, which is either your own code, or code that your company allows you to publish. You want to give us this code. We may decide to use this code. You are not going to sue people who use this code, because, after all, you are giving it to an open source project! And if you include code that you didn't write, you'll tell us about it by including the open source license to such code in your contribution so we'll know about it. You are not promising that this code works well, or that you will support it, and we're OK with that.
+
+2. [Fork][fork] the repository.
+
+3. Ensure that all tests are passing prior to submitting.
+
+4. If you are adding new functionality, or fixing a bug, provide test coverage.
+
+5. Follow syntax guidelines detailed below.
+
+6. Push the changes to your fork and submit a pull request.  If this resolves any issues, please mark in the body `resolve #ID` within the body of your pull request.  This allows for github to automatically close the related issue once the pull request is merged.
+
+7. Last step, [submit the pull request][pr]!
+
+[pr]: https://github.com/yahoo/react-intl/compare/
+[fork]: https://github.com/yahoo/react-intl/fork/
+
+## Releasing a new version
+
+The following the process to release a new version of the `react-intl` package on npm. This repo uses a protected `master` branch so the process involves creating a Pull Request for the version bump:
+
+1. Make sure local `node_modules` is up to date: `rm -rf node_modules && npm install`.
+
+2. Create a release branch from `master`: `git checkout -b release`
+
+3. Bump version using `npm version` and choose appropriate `patch`, `minor`, `major` argument.
+
+4. Create a Pull Request for your local `release` branch so Travis CI tests run.
+
+5. If all the tests pass successfully, publish your local `release` branch to npm: `npm publish`.
+
+6. Push the Git tag to the main fork: `git push upstream --tags`.
+
+7. Merge the `release` branch PR into `master` **and make sure to create a merge commit** so the Git tag matches.
+
+8. Create a [release](https://github.com/yahoo/react-intl/releases) post for the new release Git tag.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,29 @@
+Software License Agreement (BSD License)
+========================================
+
+Copyright (c) 2014-present, Yahoo Inc. All rights reserved.
+----------------------------------------------------
+
+Redistribution and use of this software in source and binary forms, with or
+without modification, are permitted provided that the following conditions are
+met:
+
+  * Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+  * Neither the name of Yahoo Inc. nor the names of this package's contributors 
+    may be used to endorse or promote products derived from this software 
+    without specific prior written permission of Yahoo Inc.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
-# formatjs
-Monorepo for all formatjs libraries.
+# FormatJS
+
+This repository is the home of [FormatJS](http://formatjs.io/) and related libraries.
+
+## Development
+
+Development is currently being done against the latest Node LTS. This repository leverages [Lerna][] for package management.
+
+Releases can be done with the following steps:
+
+```js
+> lerna publish
+```
+
+## License
+
+This software is free to use under the Yahoo Inc. BSD license.
+See the [LICENSE file][] for license text and copyright information.
+
+[LICENSE file]: https://github.com/formatjs/formatjs/blob/master/LICENSE.md
+[Lerna]: https://lernajs.io/

--- a/lerna.json
+++ b/lerna.json
@@ -1,0 +1,4 @@
+{
+  "registry": "https://registry.npmjs.org/",
+  "version": "independent"
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "formatjs-repo",
+  "version": "1.0.0",
+  "private": true,
+  "description": "This repository is the home of FormatJS and related libraries.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/formatjs/formatjs"
+  },
+  "scripts": {
+    "build": "npm run build:bootstrap && npm run build:packages",
+    "build:bootstrap": "lerna bootstrap --hoist --since --include-filtered-dependencies --no-ci",
+    "build:packages": "lerna run build --since master --stream",
+    "cover": "lerna run cover --since",
+    "cover:collect": "mkdir -p ./.nyc_output/ && for d in $(find packages -type d -name '.nyc_output' -maxdepth 2 -exec find '{}' -type f ';'); do (cp $d ./.nyc_output/); done; nyc report --reporter=lcov --report-dir=${COVERAGE_DIR:-artifacts/coverage}",
+    "dev:lint": "lerna run lint --since master --stream",
+    "dev:test": "lerna run test --since master --stream",
+    "lint": "eslint .",
+    "test": "lerna run lint --since --stream && lerna run test --since --stream"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "coveralls": "^3.0.3",
+    "eslint": "^5.16.0",
+    "lerna": "^3.13.4",
+    "nyc": "^14.1.1"
+  },
+  "devEngines": {
+    "node": "8.x || 10.x || 12.x",
+    "npm": "6.x"
+  },
+  "pre-commit": [
+    "dev:lint",
+    "dev:test"
+  ],
+  "author": "Seth Bertalotto <sbertal@verizonmedia.com>",
+  "license": "BSD-3-Clause"
+}


### PR DESCRIPTION
This is the initial skeleton. We can slowly add packages as we go. Only requirements are that all devDeps from migrated packages need to be moved to the monorepo root. The monorepo will automatically execute `build`, `lint` and `test` run scripts for the packages that changed.

We can change and test all this out once packages are migrated.