### PR TITLE
rm optional whitespace before messageFormatPattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
-/artifacts
-/.nyc_output
-/coverage
-/dist
-/node_modules
+artifacts
+.nyc_output
+coverage
+dist
+node_modules
 *.log
 *.tgz
 package-lock.json

--- a/packages/intl-messageformat-parser/.gitignore
+++ b/packages/intl-messageformat-parser/.gitignore
@@ -1,6 +1,2 @@
-.nyc_output/
-coverage/
-dist/
 lib/
-node_modules/
 src/parser.js

--- a/packages/intl-messageformat-parser/src/parser.pegjs
+++ b/packages/intl-messageformat-parser/src/parser.pegjs
@@ -28,19 +28,10 @@ messageFormatElement
     / argumentElement
 
 messageText
-    = text:(_ chars _)+ {
-        var string = '',
-            i, j, outerLen, inner, innerLen;
-
-        for (i = 0, outerLen = text.length; i < outerLen; i += 1) {
-            inner = text[i];
-
-            for (j = 0, innerLen = inner.length; j < innerLen; j += 1) {
-                string += inner[j];
-            }
-        }
-
-        return string;
+    = chunks:(_ chars _)+ {
+        return chunks.reduce(function (all, chunk) {
+            return all.concat(chunk)
+        }, []).join('')
     }
     / $(ws)
 
@@ -118,7 +109,7 @@ selector
     / chars
 
 optionalFormatPattern
-    = _ selector:selector _ '{' _ pattern:messageFormatPattern _ '}' {
+    = _ selector:selector _ '{' pattern:messageFormatPattern '}' {
         return {
             type    : 'optionalFormatPattern',
             selector: selector,

--- a/packages/intl-messageformat-parser/test/unit/parser.js
+++ b/packages/intl-messageformat-parser/test/unit/parser.js
@@ -411,6 +411,14 @@ describe('parse()', function () {
             expect(element.format.type).to.equal('numberFormat');
             expect(element.format.style).to.equal('percent');
         });
+        it('should capture whitespace in nested pattern', function () {
+            var msg = '{c, plural, =1 { {text} project} other { {text} projects}}'
+            var ast = parse(msg)
+            expect(ast.elements[0].format.options[0].value.elements).to.have.length(3)
+            expect(ast.elements[0].format.options[0].value.elements[0].value).to.equal(' ')
+            expect(ast.elements[0].format.options[0].value.elements[1].id).to.equal('text')
+            expect(ast.elements[0].format.options[0].value.elements[2].value).to.equal(' project')
+        })
     });
 
     describe('escaping', function () {


### PR DESCRIPTION
because messageFormatPattern already accounts for whitespace.
This prevents us from swallowing extra whitespaces
Fixes #5