### PR TITLE
ci(travis): saucelabs integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ node_js:
 before_script: npm run build
 script: npm test
 after_success:
-  - "npm run cover"
-  - "npm run cover:collect"
-  - "cat artifacts/coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
+  - npm run cover
+  - npm run cover:collect
+  - cat artifacts/coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
+addons:
+  sauce_connect: true

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "npm run build:bootstrap && npm run build:packages",
     "build:bootstrap": "lerna bootstrap --hoist --since --include-filtered-dependencies --no-ci",
-    "build:packages": "lerna run build --since master --stream",
+    "build:packages": "lerna run build --since --stream",
     "cover": "lerna run cover --since",
     "cover:collect": "mkdir -p ./.nyc_output/ && for d in $(find packages -type d -name '.nyc_output' -maxdepth 2 -exec find '{}' -type f ';'); do (cp $d ./.nyc_output/); done; nyc report --reporter=lcov --report-dir=${COVERAGE_DIR:-artifacts/coverage}",
     "dev:lint": "lerna run lint --since master --stream",


### PR DESCRIPTION
Sets up the initial plumbing for when `intl-messageformat` is migrated to this repo. Travis will add `SAUCE_USERNAME` and `SAUCE_ACCESS_KEY` to the project when it runs. Depending on the integration, saucelabs will be able to use these to authenticate.