### PR TITLE
feat(babel-plugin-react-intl): add `extractFromFormatMessageCall` option to opt-in extracting …

### DIFF
--- a/packages/babel-plugin-react-intl/README.md
+++ b/packages/babel-plugin-react-intl/README.md
@@ -55,6 +55,8 @@ If a message descriptor has a `description`, it'll be removed from the source af
 
 - **`additionalComponentNames`**: Additional component names to extract messages from, e.g: `['FormattedFooBarMessage']`. **NOTE**: By default we check for the fact that `FormattedMessage` & `FormattedHTMLMessage` are imported from `moduleSourceName` to make sure variable alias works. This option does not do that so it's less safe.
 
+- **`extractFromFormatMessageCall`**: Opt-in to extract from `intl.formatMessage` call with the same restrictions, e.g: has to be called with object literal such as `intl.formatMessage({ id: 'foo', defaultMessage: 'bar', description: 'baz'})`
+
 ### Via Node API
 
 The extract message descriptors are available via the `metadata` property on the object returned from Babel's `transform()` API:

--- a/packages/babel-plugin-react-intl/src/index.js
+++ b/packages/babel-plugin-react-intl/src/index.js
@@ -390,7 +390,7 @@ export default function({ types: t }) {
             .forEach(processMessageObject);
         }
 
-        if (isFormatMessageCall(callee)) {
+        if (opts.extractFromFormatMessageCall && isFormatMessageCall(callee)) {
           const messagesObj = path.get('arguments')[0];
           processMessageObject(messagesObj);
         }

--- a/packages/babel-plugin-react-intl/test/__snapshots__/index.test.js.snap
+++ b/packages/babel-plugin-react-intl/test/__snapshots__/index.test.js.snap
@@ -116,7 +116,7 @@ class Foo extends _react.Component {
 exports.default = Foo;"
 `;
 
-exports[`emit asserts for:  output match: formatMessage 1`] = `
+exports[`emit asserts for:  output match: extractFromFormatMessageCallFalse 1`] = `
 "\\"use strict\\";
 
 Object.defineProperty(exports, \\"__esModule\\", {
@@ -134,15 +134,20 @@ class Foo extends _react.Component {
   render() {
     const msgs = {
       baz: this.props.intl.formatMessage({
-        \\"id\\": \\"foo.bar.baz\\",
-        \\"defaultMessage\\": \\"Hello World!\\"
+        id: 'foo.bar.baz',
+        defaultMessage: 'Hello World!',
+        description: 'The default message'
       }),
       biff: this.props.intl.formatMessage({
-        \\"id\\": \\"foo.bar.biff\\",
-        \\"defaultMessage\\": \\"Hello Nurse!\\"
+        id: 'foo.bar.biff',
+        defaultMessage: 'Hello Nurse!',
+        description: 'Another message'
       })
     };
-    return _react.default.createElement(\\"div\\", null, _react.default.createElement(\\"h1\\", null, msgs.header), _react.default.createElement(\\"p\\", null, msgs.content));
+    return _react.default.createElement(\\"div\\", null, _react.default.createElement(\\"h1\\", null, msgs.header), _react.default.createElement(\\"p\\", null, msgs.content), _react.default.createElement(\\"span\\", null, _react.default.createElement(_reactIntl.FormattedMessage, {
+      id: \\"foo\\",
+      defaultMessage: \\"bar\\"
+    })));
   }
 
 }

--- a/packages/babel-plugin-react-intl/test/fixtures/extractFromFormatMessageCallFalse/actual.js
+++ b/packages/babel-plugin-react-intl/test/fixtures/extractFromFormatMessageCallFalse/actual.js
@@ -1,0 +1,29 @@
+import React, {Component} from 'react';
+import {injectIntl, FormattedMessage} from 'react-intl';
+
+class Foo extends Component {
+    render() {
+        const msgs = {
+            baz: this.props.intl.formatMessage({
+                id: 'foo.bar.baz',
+                defaultMessage: 'Hello World!',
+                description: 'The default message',
+            }),
+            biff: this.props.intl.formatMessage({
+                id: 'foo.bar.biff',
+                defaultMessage: 'Hello Nurse!',
+                description: 'Another message',
+            }),
+        };
+
+        return (
+            <div>
+                <h1>{msgs.header}</h1>
+                <p>{msgs.content}</p>
+                <span><FormattedMessage id="foo" defaultMessage="bar" description="baz" /></span>
+            </div>
+        );
+    }
+}
+
+export default injectIntl(Foo);

--- a/packages/babel-plugin-react-intl/test/fixtures/extractFromFormatMessageCallFalse/expected.json
+++ b/packages/babel-plugin-react-intl/test/fixtures/extractFromFormatMessageCallFalse/expected.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": "foo",
+    "description": "baz",
+    "defaultMessage": "bar"
+  }
+]

--- a/packages/babel-plugin-react-intl/test/index.test.js
+++ b/packages/babel-plugin-react-intl/test/index.test.js
@@ -17,7 +17,8 @@ const skipTests = [
   'removeDescriptions',
   'overrideIdFn',
   'removeDefaultMessage',
-  'additionalComponentNames'
+  'additionalComponentNames',
+  'formatMessage'
 ];
 
 const fixturesDir = path.join(__dirname, 'fixtures');
@@ -151,6 +152,24 @@ describe('options', () => {
     expect(() =>
       transform(path.join(fixtureDir, 'actual.js'), {
         extractSourceLocation: true
+      })
+    ).not.toThrow();
+
+    // Check message output
+    const expectedMessages = fs.readFileSync(
+      path.join(fixtureDir, 'expected.json')
+    );
+    const actualMessages = fs.readFileSync(
+      path.join(fixtureDir, 'actual.json')
+    );
+    expect(trim(actualMessages)).toEqual(trim(expectedMessages));
+  });
+
+  it('respects formatMessage', () => {
+    const fixtureDir = path.join(fixturesDir, 'formatMessage');
+    expect(() =>
+      transform(path.join(fixtureDir, 'actual.js'), {
+        extractFromFormatMessageCall: true
       })
     ).not.toThrow();
 


### PR DESCRIPTION
…from `intl.formatMessage`, fixes #37