### PR TITLE
fix ES5 compatibility in intl-locales-supported

### DIFF
--- a/packages/intl-locales-supported/index.js
+++ b/packages/intl-locales-supported/index.js
@@ -3,6 +3,6 @@
  * Copyrights licensed under the New BSD License.
  * See the accompanying LICENSE file for terms.
  */
-const areIntlLocalesSupported = require('./lib')['default']
+var areIntlLocalesSupported = require('./lib')['default']
 module.exports = areIntlLocalesSupported;
 module.exports.default = areIntlLocalesSupported;


### PR DESCRIPTION
Fix an incompatibility with ES5 introduced in https://github.com/formatjs/formatjs/pull/41
