### PR TITLE
Fix @formatjs/intl-relativetimeformat/polyfill import

### DIFF
--- a/packages/intl-relativetimeformat/polyfill.js
+++ b/packages/intl-relativetimeformat/polyfill.js
@@ -1,2 +1,2 @@
 var polyfill = require('./dist/polyfill').default
-polyfill(require('./dist'))
+polyfill(require('./dist').default)


### PR DESCRIPTION
`./dist` is an es module so we need to require `.default`