### PR TITLE
fix(intl-messageformat): to compile core.js to commonjs

### DIFF
--- a/packages/intl-messageformat/tsconfig.core.json
+++ b/packages/intl-messageformat/tsconfig.core.json
@@ -1,6 +1,7 @@
 {
     "extends": "./tsconfig.json",
     "compilerOptions": {
+        "module": "commonjs",
         "outDir": "."
     },
     "files": ["core.ts"]


### PR DESCRIPTION
## Problem
Currently the `intl-messageformat/core.js` file is compiled to ESM:

```js
export * from './lib/core';
```

This causes other libraries such as `react-intl` to break: https://github.com/formatjs/react-intl/issues/1371

## Solution
We need to instruct TS to compile to commonjs:

```js
"use strict";
function __export(m) {
    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
}
Object.defineProperty(exports, "__esModule", { value: true });
__export(require("./lib/core"));
```