### PR TITLE
Fix AST printer to print white-spaces, commas and element types correctly

### DIFF
--- a/packages/intl-messageformat-parser/src/printer.ts
+++ b/packages/intl-messageformat-parser/src/printer.ts
@@ -19,7 +19,8 @@ import {
   isDateElement,
   isTimeElement,
   isNumberElement,
-  isPluralElement
+  isPluralElement,
+  TYPE
 } from './types';
 
 const ESCAPED_CHARS: Record<string, string> = {
@@ -67,7 +68,7 @@ function printArgumentElement({ value }: ArgumentElement) {
 function printSimpleFormatElement(
   el: DateElement | TimeElement | NumberElement
 ) {
-  return `{${el.value}, ${el.type}${el.style ? `, ${el.style}` : ''}}`;
+  return `{${el.value}, ${TYPE[el.type]}${el.style ? `, ${el.style}` : ''}}`;
 }
 function printSelectElement(el: SelectElement) {
   const msg = [

--- a/packages/intl-messageformat-parser/src/printer.ts
+++ b/packages/intl-messageformat-parser/src/printer.ts
@@ -74,9 +74,9 @@ function printSelectElement(el: SelectElement) {
     el.value,
     'select',
     Object.keys(el.options)
-      .map(id => `${id}{${printAST(el.options[id].value)}}`)
+      .map(id => `${id} {${printAST(el.options[id].value)}}`)
       .join(' ')
-  ].join(',');
+  ].join(', ');
   return `{${msg}}`;
 }
 
@@ -85,10 +85,10 @@ function printPluralElement(el: PluralElement) {
   const msg = [
     el.value,
     type,
-    el.offset ? `offset:${el.offset}` : '',
+    el.offset ? `offset: ${el.offset}` : '',
     Object.keys(el.options)
-      .map(id => `${id}{${printAST(el.options[id].value)}}`)
+      .map(id => `${id} {${printAST(el.options[id].value)}}`)
       .join(' ')
-  ].join(',');
+  ].filter(t => t !== '').join(', ');
   return `{${msg}}`;
 }


### PR DESCRIPTION
As mentioned in issue #117

This message will be printed as...
```
"{count, plural, one {# file} other {# files}}"
```

Before fix: 
```
"{count,plural,,one{{count, 2} file} other{{count, 2} files}}"
```

After fix:
```
"{count, plural, one {{count, number} file} other {{count, number} files}}"
```