### PR TITLE
feat(intl-messageformat): Add xml formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
     "ts-node": "^8.1.0",
     "ts-pegjs": "^0.2.5",
     "tslib": "^1.10.0",
-    "typescript": "^3.4.5"
+    "typescript": "^3.4.5",
+    "xmldom": "^0.1.27"
   },
   "devEngines": {
     "node": "8.x || 10.x || 12.x",

--- a/packages/intl-messageformat/.gitignore
+++ b/packages/intl-messageformat/.gitignore
@@ -4,3 +4,4 @@ tests/*.js*
 .tsbuildinfo
 core.js
 core.d.ts
+!tests/setup.js

--- a/packages/intl-messageformat/README.md
+++ b/packages/intl-messageformat/README.md
@@ -158,6 +158,16 @@ _Note: A value **must** be supplied for every argument in the message pattern th
 
 Return the underlying AST for the compiled message
 
+#### `formatXMLMessage` method
+
+Formats message containing XML tags & can be used to embed rich text formatters such as React. For example:
+
+```tsx
+var mf = new IntlMessageFormat('hello <b>world</b>', 'en');
+mf.formatXMLMessage({ b: str => <span>{str}</span> });
+// returns ['hello ', React element rendered as <span>world</span>]
+```
+
 #### User Defined Formats
 
 Define custom format styles is useful you need supply a set of options to the underlying formatter; e.g., outputting a number in USD:

--- a/packages/intl-messageformat/core.ts
+++ b/packages/intl-messageformat/core.ts
@@ -1,1 +1,2 @@
-export * from './lib/core'
+export * from './lib/formatters';
+export * from './lib/core';

--- a/packages/intl-messageformat/package.json
+++ b/packages/intl-messageformat/package.json
@@ -41,7 +41,7 @@
     "karma:ci": "karma start karma.conf-ci.js",
     "karma:local": "karma start karma.conf.js",
     "rollup": "rollup -c rollup.config.js",
-    "test": "TS_NODE_PROJECT='./tsconfig.cjs.json' mocha --opts ../../mocha.opts tests/index.ts",
+    "test": "TS_NODE_PROJECT='./tsconfig.cjs.json' mocha --opts ../../mocha.opts -r tests/setup.js tests/index.ts",
     "tsc:core": "tsc -p tsconfig.core.json",
     "tsc": "tsc -p src/tsconfig.json && tsc -p src/tsconfig.cjs.json"
   },

--- a/packages/intl-messageformat/src/core.ts
+++ b/packages/intl-messageformat/src/core.ts
@@ -21,7 +21,10 @@ import {
   Formatters,
   Formats,
   formatToString,
-  formatToParts
+  formatToParts,
+  FormatXMLElementFn,
+  formatXMLMessage,
+  PrimitiveType
 } from './formatters';
 
 // -- MessageFormat --------------------------------------------------------
@@ -180,9 +183,7 @@ export class IntlMessageFormat {
     prewarmFormatters(this.ast, this.locale, this.formatters, this.formats);
   }
 
-  format = (
-    values?: Record<string, string | number | boolean | null | undefined>
-  ) =>
+  format = (values?: Record<string, PrimitiveType>) =>
     formatToString(
       this.ast,
       this.locale,
@@ -194,6 +195,17 @@ export class IntlMessageFormat {
 
   formatToParts = (values?: Record<string, any>) =>
     formatToParts(
+      this.ast,
+      this.locale,
+      this.formatters,
+      this.formats,
+      values,
+      this.message
+    );
+  formatXMLMessage = (
+    values?: Record<string, PrimitiveType | FormatXMLElementFn>
+  ) =>
+    formatXMLMessage(
       this.ast,
       this.locale,
       this.formatters,

--- a/packages/intl-messageformat/tests/index.ts
+++ b/packages/intl-messageformat/tests/index.ts
@@ -506,6 +506,40 @@ describe('IntlMessageFormat', function() {
     });
   });
 
+  describe('xml', function() {
+    it('simple message', function() {
+      var mf = new IntlMessageFormat('hello <b>world</b>', 'en');
+      expect(mf.formatXMLMessage({ b: str => ({ str }) })).to.deep.equal([
+        'hello ',
+        { str: 'world' }
+      ]);
+    });
+    it('simple message w/ placeholder', function() {
+      var mf = new IntlMessageFormat(
+        'hello <b>world</b> <a>{placeholder}</a>',
+        'en'
+      );
+      expect(
+        mf.formatXMLMessage({
+          b: str => ({ str }),
+          placeholder: 'gaga',
+          a: str => ({ str })
+        })
+      ).to.deep.equal(['hello ', { str: 'world' }, ' ', { str: 'gaga' }]);
+    });
+    it('should treat tag as legacy HTML if no value is provided', function() {
+      var mf = new IntlMessageFormat(
+        'hello <b>world</b> <a>{placeholder}</a>',
+        'en'
+      );
+      expect(
+        mf.formatXMLMessage({
+          placeholder: 'gaga'
+        })
+      ).to.deep.equal(['hello <b>world</b> <a>gaga</a>']);
+    });
+  });
+
   it('custom formats should work for time', function() {
     var msg = 'Today is {time, time, verbose}';
     var mf = new IntlMessageFormat(msg, 'en', {

--- a/packages/intl-messageformat/tests/setup.js
+++ b/packages/intl-messageformat/tests/setup.js
@@ -1,0 +1,1 @@
+global.DOMParser = require('xmldom').DOMParser;


### PR DESCRIPTION
`formatXMLMessage` method

Formats message containing XML tags & can be used to embed rich text
formatters such as React. For example:

```tsx
var mf = new IntlMessageFormat('hello <b>world</b>', 'en');
mf.formatXMLMessage({ b: str => <span>{str}</span> });
// returns ['hello ', React element rendered as <span>world</span>]
```