### PR TITLE
feat(intl-messageformat): allow mixed placeholder & XML together in a message

### DIFF
--- a/packages/intl-messageformat/src/formatters.ts
+++ b/packages/intl-messageformat/src/formatters.ts
@@ -235,15 +235,15 @@ export function formatToString(
   return parts.reduce((all, part) => (all += part.value), '');
 }
 
-export type FormatXMLElementFn = (str?: string) => string | object;
+export type FormatXMLElementFn = (...args: any[]) => string | object;
 
 // Singleton
 let domParser: DOMParser;
-const TOKEN_DELIMITER = '@@'
-const TOKEN_REGEX = /@@(.*)@@/
-let counter = 0
-function generateId () {
-  return `${TOKEN_DELIMITER}${Date.now()}_${++counter}${TOKEN_DELIMITER}`
+const TOKEN_DELIMITER = '@@';
+const TOKEN_REGEX = /@@(.*)@@/;
+let counter = 0;
+function generateId() {
+  return `${Date.now()}_${++counter}`;
 }
 
 export function formatXMLMessage(
@@ -263,16 +263,15 @@ export function formatXMLMessage(
     values,
     originalMessage
   );
-  const objectParts: Record<string, ArgumentPart> = {}
+  const objectParts: Record<string, ArgumentPart['value']> = {};
   const formattedMessage = parts.reduce((all, part) => {
     if (typeof part.value === 'string' || part.type === PART_TYPE.literal) {
-      return all += part.value
+      return (all += part.value);
     }
-    const id = generateId()
-    objectParts[generateId()] = part
-    return all += id
+    const id = generateId();
+    objectParts[id] = part.value;
+    return (all += `${TOKEN_DELIMITER}${id}${TOKEN_DELIMITER}`);
   }, '');
-  const objectPartIds = Object.keys(objectParts)
 
   // Not designed to filter out aggressively
   if (!~formattedMessage.indexOf('<')) {
@@ -312,27 +311,44 @@ export function formatXMLMessage(
     return [formattedMessage];
   }
 
-  const reconstructedChunks: Array<string | object> = [];
-  for (let i = 0; i < content.childNodes.length; i++) {
-    const node = content.childNodes[i] as Element;
-    const { tagName } = node;
-    if (!tagName) {
+  const childNodes = Array.prototype.slice.call(content.childNodes);
+  return childNodes.reduce(
+    (reconstructedChunks, { tagName, outerHTML, textContent }: Element) => {
       // Regular text
-      reconstructedChunks.push(node.textContent || '');
-    } else if (!values[tagName]) {
-      const chunk = node.outerHTML.
+      if (!tagName) {
+        const chunks = (textContent || '').split(TOKEN_REGEX).filter(Boolean);
+        return reconstructedChunks.concat(
+          ...chunks.map(c => objectParts[c] || c)
+        );
+      }
+
       // Legacy HTML
-      reconstructedChunks.push(node.outerHTML);
-    } else {
+      if (!values[tagName]) {
+        const chunks = outerHTML.split(TOKEN_REGEX).filter(Boolean);
+        if (chunks.length === 1) {
+          return reconstructedChunks.concat([chunks[0]]);
+        }
+
+        return reconstructedChunks.concat(
+          ...chunks.map(c => objectParts[c] || c)
+        );
+      }
+
+      // XML Tag replacement
       const formatFnOrValue = values[tagName];
       if (typeof formatFnOrValue === 'function') {
-        reconstructedChunks.push(
-          formatFnOrValue(node.textContent || undefined)
-        );
-      } else {
-        reconstructedChunks.push(formatFnOrValue as object);
+        if (textContent == null) {
+          return reconstructedChunks.concat([
+            formatFnOrValue(textContent || undefined)
+          ]);
+        }
+        const chunks = textContent.split(TOKEN_REGEX).filter(Boolean);
+        return reconstructedChunks.concat([
+          formatFnOrValue(...chunks.map(c => objectParts[c] || c))
+        ]);
       }
-    }
-  }
-  return reconstructedChunks;
+      return reconstructedChunks.concat([formatFnOrValue as object]);
+    },
+    []
+  );
 }

--- a/packages/intl-messageformat/tests/index.ts
+++ b/packages/intl-messageformat/tests/index.ts
@@ -546,6 +546,26 @@ describe('IntlMessageFormat', function() {
         })
       ).to.deep.equal(['hello ', {}, ' test']);
     });
+    it('should handle self-closing tag w/ rich text', function() {
+      var mf = new IntlMessageFormat('hello <foo/> {bar} test', 'en');
+      expect(
+        mf.formatXMLMessage({
+          foo: {},
+          bar: {}
+        })
+      ).to.deep.equal(['hello ', {}, ' ', {}, ' test']);
+    });
+    it('should handle tag w/ rich text', function() {
+      var mf = new IntlMessageFormat('hello <foo>{bar}</foo> test', 'en');
+      expect(
+        mf.formatXMLMessage({
+          foo: obj => ({
+            obj
+          }),
+          bar: { bar: 1 }
+        })
+      ).to.deep.equal(['hello ', { obj: { bar: 1 } }, ' test']);
+    });
   });
 
   it('custom formats should work for time', function() {


### PR DESCRIPTION
So that this still works
```tsx
var mf = new IntlMessageFormat('hello <foo>{bar}</foo> test', 'en');

mf.formatXMLMessage({
    foo: obj => ({
        obj
    }),
    bar: { bar: 1 }
})
```