### PR TITLE
feat(intl-messageformat-parser): add parser for number skeleton and date skeleton

### DIFF
--- a/packages/intl-messageformat-parser/build.js
+++ b/packages/intl-messageformat-parser/build.js
@@ -1,57 +1,65 @@
 #!/usr/bin/env node
-const peg = require('pegjs')
-const tspegjs = require("ts-pegjs");
-const fs = require('fs')
-const {outputFileSync} = require('fs-extra')
-const grammar = fs.readFileSync('./src/parser.pegjs', 'utf-8')
+const peg = require('pegjs');
+const tspegjs = require('ts-pegjs');
+const fs = require('fs');
+const { outputFileSync } = require('fs-extra');
+const grammar = fs.readFileSync('./src/parser.pegjs', 'utf-8');
 
 // TS
 const srcString = peg.generate(grammar, {
-    plugins: [tspegjs],
-    output: 'source',
-    tspegjs: {
-        customHeader: `
-import { 
-    MessageFormatElement, 
-    LiteralElement, 
-    ArgumentElement, 
-    NumberElement, 
-    DateElement, 
-    TimeElement, 
-    SelectElement, 
+  plugins: [tspegjs],
+  output: 'source',
+  tspegjs: {
+    customHeader: `
+import {
+    MessageFormatElement,
+    LiteralElement,
+    ArgumentElement,
+    NumberElement,
+    DateElement,
+    TimeElement,
+    SelectElement,
     PluralElement,
     PluralOrSelectOption,
-    TYPE
+    NumberSkeleton,
+    DateSkeleton,
+    SKELETON_TYPE,
+    TYPE,
 } from './types'`
-    },
-    returnTypes: {
-        argument: 'string',
-        ws: 'string',
-        digit: 'string',
-        hexDigit: 'string',
-        quoteEscapedChar: 'string',
-        apostrophe: 'string',
-        escape: 'string',
-        char: 'string',
-        chars: 'string',
-        varName: 'string',
-        number: 'number',
-        start: 'MessageFormatElement[]',
-        message: 'MessageFormatElement[]',
-        literalElement: 'LiteralElement',
-        argumentElement: 'ArgumentElement',
-        selectElement: 'SelectElement',
-        pluralElement: 'PluralElement',
-        selectOption: 'PluralOrSelectOption',
-        pluralOption: 'PluralOrSelectOption',
-        simpleFormatElement: `
-| NumberElement 
-| DateElement 
-| TimeElement 
+  },
+  returnTypes: {
+    argument: 'string',
+    ws: 'string',
+    digit: 'string',
+    hexDigit: 'string',
+    quoteEscapedChar: 'string',
+    apostrophe: 'string',
+    escape: 'string',
+    char: 'string',
+    chars: 'string',
+    varName: 'string',
+    number: 'number',
+    start: 'MessageFormatElement[]',
+    message: 'MessageFormatElement[]',
+    literalElement: 'LiteralElement',
+    argumentElement: 'ArgumentElement',
+    selectElement: 'SelectElement',
+    pluralElement: 'PluralElement',
+    selectOption: 'PluralOrSelectOption',
+    pluralOption: 'PluralOrSelectOption',
+    numberSkeleton: 'NumberSkeleton',
+    dateOrTimeSkeleton: 'DateSkeleton',
+    simpleFormatElement: `
+| NumberElement
+| DateElement
+| TimeElement
 `
-    }
-})
+  }
+});
 
-const REGEX = /ParseFunction = \((.*?)\) => (any);/g
+const REGEX = /ParseFunction = \((.*?)\) => (any);/g;
 
-outputFileSync('src/parser.ts', srcString.replace(REGEX, 'ParseFunction = ($1) => MessageFormatElement[];'))
+outputFileSync(
+  'src/parser.ts',
+  srcString.replace(REGEX, 'ParseFunction = ($1) => MessageFormatElement[];')
+);

--- a/packages/intl-messageformat-parser/package.json
+++ b/packages/intl-messageformat-parser/package.json
@@ -10,7 +10,8 @@
     "build": "./build.js && tsc && tsc -p tsconfig.cjs.json",
     "benchmark": "node ./test/benchmark.js",
     "prepublish": "npm run build",
-    "test": "TS_NODE_PROJECT='./tsconfig.cjs.json' cross-env NODE_ENV=test jest"
+    "test": "TS_NODE_PROJECT='./tsconfig.cjs.json' cross-env NODE_ENV=test jest",
+    "watch:test": "TS_NODE_PROJECT='./tsconfig.cjs.json' cross-env NODE_ENV=test jest"
   },
   "contributors": [
     "Eric Ferraiuolo <eferraiuolo@gmail.com>",

--- a/packages/intl-messageformat-parser/package.json
+++ b/packages/intl-messageformat-parser/package.json
@@ -10,8 +10,7 @@
     "build": "./build.js && tsc && tsc -p tsconfig.cjs.json",
     "benchmark": "node ./test/benchmark.js",
     "prepublish": "npm run build",
-    "test": "TS_NODE_PROJECT='./tsconfig.cjs.json' cross-env NODE_ENV=test jest",
-    "watch:test": "TS_NODE_PROJECT='./tsconfig.cjs.json' cross-env NODE_ENV=test jest"
+    "test": "TS_NODE_PROJECT='./tsconfig.cjs.json' cross-env NODE_ENV=test jest"
   },
   "contributors": [
     "Eric Ferraiuolo <eferraiuolo@gmail.com>",

--- a/packages/intl-messageformat-parser/src/parser.pegjs
+++ b/packages/intl-messageformat-parser/src/parser.pegjs
@@ -58,8 +58,30 @@ argumentElement 'argumentElement'
         }
     }
 
-simpleFormatElement 
-    = '{' _ value:varName _ ',' _ type:('number' / 'date' / 'time') _ style:(',' _ chars)? _ '}' {
+numberSkeletonTokenOption 'numberSkeletonTokenOption'
+    = '/' option:numberSkeletonId { return option; }
+
+numberSkeletonToken 'numberSkeletonToken'
+    = _ stem:numberSkeletonId options:(numberSkeletonTokenOption*) {
+        return {stem: stem, options};
+    }
+
+// See also:
+// https://github.com/unicode-org/icu/blob/master/docs/userguide/format_parse/numbers/skeletons.md
+numberSkeleton = tokens:(numberSkeletonToken+) {
+    return {
+        type: SKELETON_TYPE.number,
+        tokens,
+        ...insertLocation()
+    }
+}
+
+numberArgStyle
+    = '::' skeleton:numberSkeleton { return skeleton; }
+    / chars
+
+numberFormatElement
+    = '{' _ value:varName _ ',' _ type:'number' _ style:(',' _ numberArgStyle)? _ '}' {
         return {
             type    : type === 'number' ? TYPE.number : type === 'date' ? TYPE.date : TYPE.time,
             style   : style && style[2],
@@ -67,6 +89,45 @@ simpleFormatElement
             ...insertLocation()
         };
     }
+
+// Starting with ICU 4.8, an ASCII apostrophe only starts quoted text if it immediately precedes
+// a character that requires quoting (that is, "only where needed"), and works the same in
+// nested messages as on the top level of the pattern. The new behavior is otherwise compatible.
+// TODO: use this rule for message text literal.
+quotedString = "'" escapedChar:([\{\}]) quotedChars:$([^'] / "''")+ "'" {
+    return escapedChar + quotedChars.replace(`''`, `'`);
+}
+doubleApostrophes = "''" { return `'`; }
+unquotedString = matches:$(!("''" / '{' / '}' / "'{" "'}") .)+ { return matches; }
+
+// See also:
+// - http://cldr.unicode.org/translation/date-time-patterns
+// - http://www.icu-project.org/apiref/icu4j/com/ibm/icu/text/SimpleDateFormat.html
+// Here we implement the ICU >= 4.8 quoting behavior.
+dateOrTimeSkeleton
+    = parts:(quotedString / doubleApostrophes / unquotedString)+ {
+        return {
+            type: SKELETON_TYPE.date,
+            pattern: parts.join(''),
+            ...insertLocation(),
+        }
+    }
+
+dateOrTimeArgStyle
+    = '::' skeleton:dateOrTimeSkeleton { return skeleton; }
+    / chars
+
+dateOrTimeFormatElement
+    = '{' _ value:varName _ ',' _ type:('date' / 'time') _ style:(',' _ dateOrTimeArgStyle)? _ '}' {
+        return {
+            type    : type === 'number' ? TYPE.number : type === 'date' ? TYPE.date : TYPE.time,
+            style   : style && style[2],
+            value,
+            ...insertLocation()
+        };
+    }
+
+simpleFormatElement = numberFormatElement / dateOrTimeFormatElement
 
 pluralElement
     = '{' _ value:varName _ ',' _ pluralType:('plural' / 'selectordinal') _ ',' _ offset:('offset:' _ number)? _ options:pluralOption+ _ '}' {
@@ -143,15 +204,15 @@ number = digits:digit+ {
     return parseInt(digits.join(''), 10);
 }
 
-quoteEscapedChar = 
+quoteEscapedChar =
   !("'" / [ \t\n\r,.+={}#]) char:. { return char; }
   / "'" sequence:escape { return sequence; }
- 
+
 apostrophe 'apostrophe' = "'"
 escape = [ \t\n\r,.+={}#] / apostrophe
 
 char
-    = 
+    =
     "'" sequence:apostrophe { return sequence; }
     / [^{}\\\0-\x1F\x7f \t\n\r]
     / '\\\\' { return '\\'; }
@@ -163,3 +224,9 @@ char
     }
 
 chars = chars:char+ { return chars.join(''); }
+
+// Equivalence of \p{Pattern_White_Space}
+// See: https://github.com/mathiasbynens/unicode-11.0.0/blob/master/Binary_Property/Pattern_White_Space/regex.js
+patternWhiteSpace = [\t-\r \x85\u200E\u200F\u2028\u2029];
+
+numberSkeletonId 'numberSkeletonId' = $(!(patternWhiteSpace / [\'\/{}]) .)+;

--- a/packages/intl-messageformat-parser/src/types.ts
+++ b/packages/intl-messageformat-parser/src/types.ts
@@ -29,6 +29,11 @@ export enum TYPE {
   plural
 }
 
+export const enum SKELETON_TYPE {
+  number,
+  date
+}
+
 export interface LocationDetails {
   offset: number;
   line: number;
@@ -95,6 +100,25 @@ export type MessageFormatElement =
   | SelectElement
   | PluralElement;
 
+export interface SkeletonToken {
+  stem: string;
+  options: string[];
+}
+
+export interface NumberSkeleton {
+  type: SKELETON_TYPE.number;
+  tokens: SkeletonToken[];
+  location?: Location;
+}
+
+export interface DateSkeleton {
+  type: SKELETON_TYPE.date;
+  pattern: string;
+  location?: Location;
+}
+
+export type Skeleton = NumberSkeleton | DateSkeleton;
+
 /**
  * Type Guards
  */
@@ -122,6 +146,12 @@ export function isSelectElement(el: MessageFormatElement): el is SelectElement {
 }
 export function isPluralElement(el: MessageFormatElement): el is PluralElement {
   return el.type === TYPE.plural;
+}
+export function isNumberSkeleton(el: Skeleton): el is NumberSkeleton {
+  return el.type === SKELETON_TYPE.number;
+}
+export function isDateSkeleton(el: Skeleton): el is DateSkeleton {
+  return el.type === SKELETON_TYPE.date;
 }
 
 export function createLiteralElement(value: string): LiteralElement {

--- a/packages/intl-messageformat-parser/test/__snapshots__/date_skeleton.test.ts.snap
+++ b/packages/intl-messageformat-parser/test/__snapshots__/date_skeleton.test.ts.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`case: "EEE, MMM d, 'yy" 1`] = `
+Array [
+  Object {
+    "style": Object {
+      "pattern": "EEE, MMM d, 'yy",
+      "type": 1,
+    },
+    "type": 3,
+    "value": 0,
+  },
+]
+`;
+
+exports[`case: "h:mm a" 1`] = `
+Array [
+  Object {
+    "style": Object {
+      "pattern": "h:mm a",
+      "type": 1,
+    },
+    "type": 3,
+    "value": 0,
+  },
+]
+`;
+
+exports[`case: "yyyy.MM.dd G at HH:mm:ss vvvv" 1`] = `
+Array [
+  Object {
+    "style": Object {
+      "pattern": "yyyy.MM.dd G at HH:mm:ss vvvv",
+      "type": 1,
+    },
+    "type": 3,
+    "value": 0,
+  },
+]
+`;

--- a/packages/intl-messageformat-parser/test/__snapshots__/number_skeleton.test.ts.snap
+++ b/packages/intl-messageformat-parser/test/__snapshots__/number_skeleton.test.ts.snap
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`case: "@@#" 1`] = `
+Array [
+  Object {
+    "style": Object {
+      "tokens": Array [
+        Object {
+          "options": Array [],
+          "stem": "@@#",
+        },
+      ],
+      "type": 0,
+    },
+    "type": 2,
+    "value": 0,
+  },
+]
+`;
+
+exports[`case: "compact-short currency/GBP" 1`] = `
+Array [
+  Object {
+    "style": Object {
+      "tokens": Array [
+        Object {
+          "options": Array [],
+          "stem": "compact-short",
+        },
+        Object {
+          "options": Array [
+            "GBP",
+          ],
+          "stem": "currency",
+        },
+      ],
+      "type": 0,
+    },
+    "type": 2,
+    "value": 0,
+  },
+]
+`;
+
+exports[`case: "currency/CAD unit-width-narrow" 1`] = `
+Array [
+  Object {
+    "style": Object {
+      "tokens": Array [
+        Object {
+          "options": Array [
+            "CAD",
+          ],
+          "stem": "currency",
+        },
+        Object {
+          "options": Array [],
+          "stem": "unit-width-narrow",
+        },
+      ],
+      "type": 0,
+    },
+    "type": 2,
+    "value": 0,
+  },
+]
+`;

--- a/packages/intl-messageformat-parser/test/date_skeleton.test.ts
+++ b/packages/intl-messageformat-parser/test/date_skeleton.test.ts
@@ -1,0 +1,8 @@
+import { parse } from '../src/parser';
+
+test.each([`yyyy.MM.dd G at HH:mm:ss vvvv`, `EEE, MMM d, 'yy`, `h:mm a`])(
+  'case: %p',
+  skeleton => {
+    expect(parse(`{0, date, ::${skeleton}}`)).toMatchSnapshot();
+  }
+);

--- a/packages/intl-messageformat-parser/test/number_skeleton.test.ts
+++ b/packages/intl-messageformat-parser/test/number_skeleton.test.ts
@@ -1,0 +1,9 @@
+import { parse } from '../src/parser';
+
+test.each([
+  `compact-short currency/GBP`,
+  `@@#`,
+  `currency/CAD unit-width-narrow`
+])('case: %p', skeleton => {
+  expect(parse(`{0, number, ::${skeleton}}`)).toMatchSnapshot();
+});

--- a/packages/intl-messageformat/tests/index.ts
+++ b/packages/intl-messageformat/tests/index.ts
@@ -519,9 +519,9 @@ describe('IntlMessageFormat', function() {
       expect(
         mf.formatXMLMessage({
           placeholder: { name: 'gaga' },
-          var2: {foo: 1}
+          var2: { foo: 1 }
         })
-      ).to.deep.equal(['hello ', { name: 'gaga' }, ' ', {foo:1}]);
+      ).to.deep.equal(['hello ', { name: 'gaga' }, ' ', { foo: 1 }]);
     });
     it('simple message w/ placeholder', function() {
       var mf = new IntlMessageFormat(

--- a/packages/intl-relativetimeformat/src/polyfill.ts
+++ b/packages/intl-relativetimeformat/src/polyfill.ts
@@ -60,9 +60,13 @@ export default function polyfill(
 
   try {
     // This is bc transpilation process sets class properties to anonymous function
-    Object.defineProperty(RelativeTimeFormat.prototype.resolvedOptions, 'name', {
-      value: 'resolvedOptions'
-    });
+    Object.defineProperty(
+      RelativeTimeFormat.prototype.resolvedOptions,
+      'name',
+      {
+        value: 'resolvedOptions'
+      }
+    );
 
     Object.defineProperty(RelativeTimeFormat.prototype.format, 'name', {
       value: 'format'


### PR DESCRIPTION
- Added parser for number skeleton and date skeleton.
- Change argument `style` to also accept skeleton object. They are:

```
export interface NumberSkeleton {
  type: SKELETON_TYPE.number;
  tokens: SkeletonToken[];
  location?: Location;
}

 export interface DateSkeleton {
  type: SKELETON_TYPE.date;
  pattern: string;
  location?: Location;
}
```

Note that these parsers do not understand the semantics, but simply tokenizes the skeleton.