### PR TITLE
feat(intl-messageformat-parser): revamped quote rule

### DIFF
--- a/packages/intl-messageformat-parser/build.js
+++ b/packages/intl-messageformat-parser/build.js
@@ -49,6 +49,8 @@ import {
     pluralOption: 'PluralOrSelectOption',
     numberSkeleton: 'NumberSkeleton',
     dateOrTimeSkeleton: 'DateSkeleton',
+    numberArgStyle: 'string | NumberSkeleton',
+    dateOrTimeArgStyle: 'string | DateSkeleton',
     simpleFormatElement: `
 | NumberElement
 | DateElement

--- a/packages/intl-messageformat-parser/src/types.ts
+++ b/packages/intl-messageformat-parser/src/types.ts
@@ -53,13 +53,14 @@ export interface BaseElement<T extends TYPE> {
 export type LiteralElement = BaseElement<TYPE.literal>;
 export type ArgumentElement = BaseElement<TYPE.argument>;
 
-export interface SimpleFormatElement<T extends TYPE> extends BaseElement<T> {
-  style?: string;
+export interface SimpleFormatElement<T extends TYPE, S extends Skeleton>
+  extends BaseElement<T> {
+  style?: string | S | null;
 }
 
-export type NumberElement = SimpleFormatElement<TYPE.number>;
-export type DateElement = SimpleFormatElement<TYPE.date>;
-export type TimeElement = SimpleFormatElement<TYPE.time>;
+export type NumberElement = SimpleFormatElement<TYPE.number, NumberSkeleton>;
+export type DateElement = SimpleFormatElement<TYPE.date, DateSkeleton>;
+export type TimeElement = SimpleFormatElement<TYPE.time, DateSkeleton>;
 
 export interface SelectOption {
   id: string;
@@ -163,7 +164,7 @@ export function createLiteralElement(value: string): LiteralElement {
 
 export function createNumberElement(
   value: string,
-  style?: string
+  style?: string | null
 ): NumberElement {
   return {
     type: TYPE.number,

--- a/packages/intl-messageformat-parser/test/__snapshots__/date_skeleton.test.ts.snap
+++ b/packages/intl-messageformat-parser/test/__snapshots__/date_skeleton.test.ts.snap
@@ -8,7 +8,7 @@ Array [
       "type": 1,
     },
     "type": 3,
-    "value": 0,
+    "value": "0",
   },
 ]
 `;
@@ -21,7 +21,7 @@ Array [
       "type": 1,
     },
     "type": 3,
-    "value": 0,
+    "value": "0",
   },
 ]
 `;
@@ -34,7 +34,7 @@ Array [
       "type": 1,
     },
     "type": 3,
-    "value": 0,
+    "value": "0",
   },
 ]
 `;

--- a/packages/intl-messageformat-parser/test/__snapshots__/index.test.ts.snap
+++ b/packages/intl-messageformat-parser/test/__snapshots__/index.test.ts.snap
@@ -9,50 +9,16 @@ Array [
 ]
 `;
 
-exports[`parse() can parse '''{name}''' 1`] = `
+exports[`parse() can parse ''#'' 1`] = `
 Array [
   Object {
     "type": 0,
-    "value": "'",
-  },
-  Object {
-    "type": 1,
-    "value": "name",
-  },
-  Object {
-    "type": 0,
-    "value": "'",
+    "value": "'#'",
   },
 ]
 `;
 
-exports[`parse() can parse '''{name}''' 2`] = `
-Array [
-  Object {
-    "type": 0,
-    "value": "'",
-  },
-  Object {
-    "type": 1,
-    "value": "name",
-  },
-  Object {
-    "type": 0,
-    "value": "'",
-  },
-]
-`;
-
-exports[`parse() can parse '\\#' 1`] = `
-Array [
-  Object {
-    "type": 0,
-    "value": "\\\\#",
-  },
-]
-`;
-
-exports[`parse() can parse '\\{' 1`] = `
+exports[`parse() can parse ''{'' 1`] = `
 Array [
   Object {
     "type": 0,
@@ -61,20 +27,20 @@ Array [
 ]
 `;
 
-exports[`parse() can parse '\\}' 1`] = `
+exports[`parse() can parse ''{name}'' 1`] = `
 Array [
   Object {
     "type": 0,
-    "value": "}",
+    "value": "{name}",
   },
 ]
 `;
 
-exports[`parse() can parse '\\u003C' 1`] = `
+exports[`parse() can parse ''}'' 1`] = `
 Array [
   Object {
     "type": 0,
-    "value": "<",
+    "value": "}",
   },
 ]
 `;
@@ -535,15 +501,7 @@ exports[`parse() can parse 'This '{isn''t}' obvious' 1`] = `
 Array [
   Object {
     "type": 0,
-    "value": "This '",
-  },
-  Object {
-    "type": 1,
-    "value": "isn't",
-  },
-  Object {
-    "type": 0,
-    "value": "' obvious",
+    "value": "This {isn't} obvious",
   },
 ]
 `;
@@ -595,17 +553,13 @@ Array [
 
 exports[`parse() can print AST from '   some random test   ' 1`] = `"   some random test   "`;
 
-exports[`parse() can print AST from '''{name}''' 1`] = `"'{name}'"`;
+exports[`parse() can print AST from ''#'' 1`] = `"'#'"`;
 
-exports[`parse() can print AST from '''{name}''' 2`] = `"'{name}'"`;
+exports[`parse() can print AST from ''{'' 1`] = `"\\\\{"`;
 
-exports[`parse() can print AST from '\\#' 1`] = `"\\\\#"`;
+exports[`parse() can print AST from ''{name}'' 1`] = `"\\\\{name\\\\}"`;
 
-exports[`parse() can print AST from '\\{' 1`] = `"\\\\{"`;
-
-exports[`parse() can print AST from '\\}' 1`] = `"\\\\}"`;
-
-exports[`parse() can print AST from '\\u003C' 1`] = `"<"`;
+exports[`parse() can print AST from ''}'' 1`] = `"\\\\}"`;
 
 exports[`parse() can print AST from '{  num , number,percent  }' 1`] = `"{num, number, percent}"`;
 
@@ -631,7 +585,7 @@ exports[`parse() can print AST from 'Hello, World!' 1`] = `"Hello, World!"`;
 
 exports[`parse() can print AST from 'My name is {FIRST} {LAST}, age {age, number}, time {time, time}, date {date, date}.' 1`] = `"My name is {FIRST} {LAST}, age {age, number}, time {time, time}, date {date, date}."`;
 
-exports[`parse() can print AST from 'This '{isn''t}' obvious' 1`] = `"This '{isn't}' obvious"`;
+exports[`parse() can print AST from 'This '{isn''t}' obvious' 1`] = `"This \\\\{isn't\\\\} obvious"`;
 
 exports[`parse() can print AST from 'this is {count,plural,offset:1 one{{count, number} dog} other{{count, number} dogs}}' 1`] = `"this is {count,plural,offset:1 one{{count, number} dog} other{{count, number} dogs}}"`;
 
@@ -644,50 +598,16 @@ Array [
 ]
 `;
 
-exports[`parse({ captureLocation: true }) can parse '''{name}''' 1`] = `
+exports[`parse({ captureLocation: true }) can parse ''#'' 1`] = `
 Array [
   Object {
     "type": 0,
-    "value": "'",
-  },
-  Object {
-    "type": 1,
-    "value": "name",
-  },
-  Object {
-    "type": 0,
-    "value": "'",
+    "value": "'#'",
   },
 ]
 `;
 
-exports[`parse({ captureLocation: true }) can parse '''{name}''' 2`] = `
-Array [
-  Object {
-    "type": 0,
-    "value": "'",
-  },
-  Object {
-    "type": 1,
-    "value": "name",
-  },
-  Object {
-    "type": 0,
-    "value": "'",
-  },
-]
-`;
-
-exports[`parse({ captureLocation: true }) can parse '\\#' 1`] = `
-Array [
-  Object {
-    "type": 0,
-    "value": "\\\\#",
-  },
-]
-`;
-
-exports[`parse({ captureLocation: true }) can parse '\\{' 1`] = `
+exports[`parse({ captureLocation: true }) can parse ''{'' 1`] = `
 Array [
   Object {
     "type": 0,
@@ -696,20 +616,20 @@ Array [
 ]
 `;
 
-exports[`parse({ captureLocation: true }) can parse '\\}' 1`] = `
+exports[`parse({ captureLocation: true }) can parse ''{name}'' 1`] = `
 Array [
   Object {
     "type": 0,
-    "value": "}",
+    "value": "{name}",
   },
 ]
 `;
 
-exports[`parse({ captureLocation: true }) can parse '\\u003C' 1`] = `
+exports[`parse({ captureLocation: true }) can parse ''}'' 1`] = `
 Array [
   Object {
     "type": 0,
-    "value": "<",
+    "value": "}",
   },
 ]
 `;
@@ -1170,15 +1090,7 @@ exports[`parse({ captureLocation: true }) can parse 'This '{isn''t}' obvious' 1`
 Array [
   Object {
     "type": 0,
-    "value": "This '",
-  },
-  Object {
-    "type": 1,
-    "value": "isn't",
-  },
-  Object {
-    "type": 0,
-    "value": "' obvious",
+    "value": "This {isn't} obvious",
   },
 ]
 `;
@@ -1230,17 +1142,13 @@ Array [
 
 exports[`parse({ captureLocation: true }) can print AST from '   some random test   ' 1`] = `"   some random test   "`;
 
-exports[`parse({ captureLocation: true }) can print AST from '''{name}''' 1`] = `"'{name}'"`;
+exports[`parse({ captureLocation: true }) can print AST from ''#'' 1`] = `"'#'"`;
 
-exports[`parse({ captureLocation: true }) can print AST from '''{name}''' 2`] = `"'{name}'"`;
+exports[`parse({ captureLocation: true }) can print AST from ''{'' 1`] = `"\\\\{"`;
 
-exports[`parse({ captureLocation: true }) can print AST from '\\#' 1`] = `"\\\\#"`;
+exports[`parse({ captureLocation: true }) can print AST from ''{name}'' 1`] = `"\\\\{name\\\\}"`;
 
-exports[`parse({ captureLocation: true }) can print AST from '\\{' 1`] = `"\\\\{"`;
-
-exports[`parse({ captureLocation: true }) can print AST from '\\}' 1`] = `"\\\\}"`;
-
-exports[`parse({ captureLocation: true }) can print AST from '\\u003C' 1`] = `"<"`;
+exports[`parse({ captureLocation: true }) can print AST from ''}'' 1`] = `"\\\\}"`;
 
 exports[`parse({ captureLocation: true }) can print AST from '{  num , number,percent  }' 1`] = `"{num, number, percent}"`;
 
@@ -1266,6 +1174,6 @@ exports[`parse({ captureLocation: true }) can print AST from 'Hello, World!' 1`]
 
 exports[`parse({ captureLocation: true }) can print AST from 'My name is {FIRST} {LAST}, age {age, number}, time {time, time}, date {date, date}.' 1`] = `"My name is {FIRST} {LAST}, age {age, number}, time {time, time}, date {date, date}."`;
 
-exports[`parse({ captureLocation: true }) can print AST from 'This '{isn''t}' obvious' 1`] = `"This '{isn't}' obvious"`;
+exports[`parse({ captureLocation: true }) can print AST from 'This '{isn''t}' obvious' 1`] = `"This \\\\{isn't\\\\} obvious"`;
 
 exports[`parse({ captureLocation: true }) can print AST from 'this is {count,plural,offset:1 one{{count, number} dog} other{{count, number} dogs}}' 1`] = `"this is {count,plural,offset:1 one{{count, number} dog} other{{count, number} dogs}}"`;

--- a/packages/intl-messageformat-parser/test/__snapshots__/nested.test.ts.snap
+++ b/packages/intl-messageformat-parser/test/__snapshots__/nested.test.ts.snap
@@ -1,0 +1,298 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`plural arg nested inside select arg 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "      ",
+  },
+  Object {
+    "options": Object {
+      "female": Object {
+        "location": undefined,
+        "value": Array [
+          Object {
+            "type": 0,
+            "value": "
+          ",
+          },
+          Object {
+            "offset": 1,
+            "options": Object {
+              "=0": Object {
+                "location": undefined,
+                "value": Array [
+                  Object {
+                    "type": 1,
+                    "value": "host",
+                  },
+                  Object {
+                    "type": 0,
+                    "value": " does not give a party.",
+                  },
+                ],
+              },
+              "=1": Object {
+                "location": undefined,
+                "value": Array [
+                  Object {
+                    "type": 1,
+                    "value": "host",
+                  },
+                  Object {
+                    "type": 0,
+                    "value": " invites ",
+                  },
+                  Object {
+                    "type": 1,
+                    "value": "guest",
+                  },
+                  Object {
+                    "type": 0,
+                    "value": " to her party.",
+                  },
+                ],
+              },
+              "=2": Object {
+                "location": undefined,
+                "value": Array [
+                  Object {
+                    "type": 1,
+                    "value": "host",
+                  },
+                  Object {
+                    "type": 0,
+                    "value": " invites ",
+                  },
+                  Object {
+                    "type": 1,
+                    "value": "guest",
+                  },
+                  Object {
+                    "type": 0,
+                    "value": " and one other person to her party.",
+                  },
+                ],
+              },
+              "other": Object {
+                "location": undefined,
+                "value": Array [
+                  Object {
+                    "type": 1,
+                    "value": "host",
+                  },
+                  Object {
+                    "type": 0,
+                    "value": " invites ",
+                  },
+                  Object {
+                    "type": 1,
+                    "value": "guest",
+                  },
+                  Object {
+                    "type": 0,
+                    "value": " and # other people to her party.",
+                  },
+                ],
+              },
+            },
+            "pluralType": "cardinal",
+            "type": 6,
+            "value": "num_guests",
+          },
+        ],
+      },
+      "male": Object {
+        "location": undefined,
+        "value": Array [
+          Object {
+            "type": 0,
+            "value": "
+          ",
+          },
+          Object {
+            "offset": 1,
+            "options": Object {
+              "=0": Object {
+                "location": undefined,
+                "value": Array [
+                  Object {
+                    "type": 1,
+                    "value": "host",
+                  },
+                  Object {
+                    "type": 0,
+                    "value": " does not give a party.",
+                  },
+                ],
+              },
+              "=1": Object {
+                "location": undefined,
+                "value": Array [
+                  Object {
+                    "type": 1,
+                    "value": "host",
+                  },
+                  Object {
+                    "type": 0,
+                    "value": " invites ",
+                  },
+                  Object {
+                    "type": 1,
+                    "value": "guest",
+                  },
+                  Object {
+                    "type": 0,
+                    "value": " to his party.",
+                  },
+                ],
+              },
+              "=2": Object {
+                "location": undefined,
+                "value": Array [
+                  Object {
+                    "type": 1,
+                    "value": "host",
+                  },
+                  Object {
+                    "type": 0,
+                    "value": " invites ",
+                  },
+                  Object {
+                    "type": 1,
+                    "value": "guest",
+                  },
+                  Object {
+                    "type": 0,
+                    "value": " and one other person to his party.",
+                  },
+                ],
+              },
+              "other": Object {
+                "location": undefined,
+                "value": Array [
+                  Object {
+                    "type": 1,
+                    "value": "host",
+                  },
+                  Object {
+                    "type": 0,
+                    "value": " invites ",
+                  },
+                  Object {
+                    "type": 1,
+                    "value": "guest",
+                  },
+                  Object {
+                    "type": 0,
+                    "value": " and # other people to his party.",
+                  },
+                ],
+              },
+            },
+            "pluralType": "cardinal",
+            "type": 6,
+            "value": "num_guests",
+          },
+        ],
+      },
+      "other": Object {
+        "location": undefined,
+        "value": Array [
+          Object {
+            "type": 0,
+            "value": "
+          ",
+          },
+          Object {
+            "offset": 1,
+            "options": Object {
+              "=0": Object {
+                "location": undefined,
+                "value": Array [
+                  Object {
+                    "type": 1,
+                    "value": "host",
+                  },
+                  Object {
+                    "type": 0,
+                    "value": " does not give a party.",
+                  },
+                ],
+              },
+              "=1": Object {
+                "location": undefined,
+                "value": Array [
+                  Object {
+                    "type": 1,
+                    "value": "host",
+                  },
+                  Object {
+                    "type": 0,
+                    "value": " invites ",
+                  },
+                  Object {
+                    "type": 1,
+                    "value": "guest",
+                  },
+                  Object {
+                    "type": 0,
+                    "value": " to their party.",
+                  },
+                ],
+              },
+              "=2": Object {
+                "location": undefined,
+                "value": Array [
+                  Object {
+                    "type": 1,
+                    "value": "host",
+                  },
+                  Object {
+                    "type": 0,
+                    "value": " invites ",
+                  },
+                  Object {
+                    "type": 1,
+                    "value": "guest",
+                  },
+                  Object {
+                    "type": 0,
+                    "value": " and one other person to their party.",
+                  },
+                ],
+              },
+              "other": Object {
+                "location": undefined,
+                "value": Array [
+                  Object {
+                    "type": 1,
+                    "value": "host",
+                  },
+                  Object {
+                    "type": 0,
+                    "value": " invites ",
+                  },
+                  Object {
+                    "type": 1,
+                    "value": "guest",
+                  },
+                  Object {
+                    "type": 0,
+                    "value": " and # other people to their party.",
+                  },
+                ],
+              },
+            },
+            "pluralType": "cardinal",
+            "type": 6,
+            "value": "num_guests",
+          },
+        ],
+      },
+    },
+    "type": 5,
+    "value": "gender_of_host",
+  },
+]
+`;

--- a/packages/intl-messageformat-parser/test/__snapshots__/none_arg.test.ts.snap
+++ b/packages/intl-messageformat-parser/test/__snapshots__/none_arg.test.ts.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`trivial 1`] = `
+Array [
+  Object {
+    "type": 1,
+    "value": "0",
+  },
+]
+`;
+
+exports[`trivial 2`] = `
+Array [
+  Object {
+    "type": 1,
+    "value": "arg",
+  },
+]
+`;
+
+exports[`trivial 3`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "hello ",
+  },
+  Object {
+    "type": 1,
+    "value": "name",
+  },
+]
+`;

--- a/packages/intl-messageformat-parser/test/__snapshots__/number_skeleton.test.ts.snap
+++ b/packages/intl-messageformat-parser/test/__snapshots__/number_skeleton.test.ts.snap
@@ -13,7 +13,7 @@ Array [
       "type": 0,
     },
     "type": 2,
-    "value": 0,
+    "value": "0",
   },
 ]
 `;
@@ -37,7 +37,7 @@ Array [
       "type": 0,
     },
     "type": 2,
-    "value": 0,
+    "value": "0",
   },
 ]
 `;
@@ -61,7 +61,7 @@ Array [
       "type": 0,
     },
     "type": 2,
-    "value": 0,
+    "value": "0",
   },
 ]
 `;

--- a/packages/intl-messageformat-parser/test/__snapshots__/plural_arg.test.ts.snap
+++ b/packages/intl-messageformat-parser/test/__snapshots__/plural_arg.test.ts.snap
@@ -1,0 +1,79 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`escaped nested message 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "      ",
+  },
+  Object {
+    "offset": 0,
+    "options": Object {
+      "one": Object {
+        "location": undefined,
+        "value": Array [
+          Object {
+            "type": 0,
+            "value": "item}",
+          },
+        ],
+      },
+      "other": Object {
+        "location": undefined,
+        "value": Array [
+          Object {
+            "type": 0,
+            "value": "items}",
+          },
+        ],
+      },
+    },
+    "pluralType": "cardinal",
+    "type": 6,
+    "value": "itemCount",
+  },
+]
+`;
+
+exports[`trivial 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "      Cart: ",
+  },
+  Object {
+    "type": 1,
+    "value": "itemCount",
+  },
+  Object {
+    "type": 0,
+    "value": " ",
+  },
+  Object {
+    "offset": 0,
+    "options": Object {
+      "one": Object {
+        "location": undefined,
+        "value": Array [
+          Object {
+            "type": 0,
+            "value": "item",
+          },
+        ],
+      },
+      "other": Object {
+        "location": undefined,
+        "value": Array [
+          Object {
+            "type": 0,
+            "value": "items",
+          },
+        ],
+      },
+    },
+    "pluralType": "cardinal",
+    "type": 6,
+    "value": "itemCount",
+  },
+]
+`;

--- a/packages/intl-messageformat-parser/test/__snapshots__/select_arg.test.ts.snap
+++ b/packages/intl-messageformat-parser/test/__snapshots__/select_arg.test.ts.snap
@@ -1,0 +1,95 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`nested arguments 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "      ",
+  },
+  Object {
+    "options": Object {
+      "other": Object {
+        "location": undefined,
+        "value": Array [
+          Object {
+            "type": 0,
+            "value": "No taxes apply.",
+          },
+        ],
+      },
+      "yes": Object {
+        "location": undefined,
+        "value": Array [
+          Object {
+            "type": 0,
+            "value": "An additional ",
+          },
+          Object {
+            "style": "percent",
+            "type": 2,
+            "value": "taxRate",
+          },
+          Object {
+            "type": 0,
+            "value": " tax will be collected.",
+          },
+        ],
+      },
+    },
+    "type": 5,
+    "value": "taxableArea",
+  },
+  Object {
+    "type": 0,
+    "value": "
+    ",
+  },
+]
+`;
+
+exports[`trivial 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "      ",
+  },
+  Object {
+    "options": Object {
+      "female": Object {
+        "location": undefined,
+        "value": Array [
+          Object {
+            "type": 0,
+            "value": "She",
+          },
+        ],
+      },
+      "male": Object {
+        "location": undefined,
+        "value": Array [
+          Object {
+            "type": 0,
+            "value": "He",
+          },
+        ],
+      },
+      "other": Object {
+        "location": undefined,
+        "value": Array [
+          Object {
+            "type": 0,
+            "value": "They",
+          },
+        ],
+      },
+    },
+    "type": 5,
+    "value": "gender",
+  },
+  Object {
+    "type": 0,
+    "value": " will respond shortly.
+    ",
+  },
+]
+`;

--- a/packages/intl-messageformat-parser/test/__snapshots__/simple_arg.test.ts.snap
+++ b/packages/intl-messageformat-parser/test/__snapshots__/simple_arg.test.ts.snap
@@ -1,0 +1,83 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`date & time arg 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "Your meeting is scheduled for the ",
+  },
+  Object {
+    "style": null,
+    "type": 3,
+    "value": "dateVal",
+  },
+  Object {
+    "type": 0,
+    "value": " at ",
+  },
+  Object {
+    "style": null,
+    "type": 4,
+    "value": "timeVal",
+  },
+]
+`;
+
+exports[`date & time arg with style 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "Your meeting is scheduled for the ",
+  },
+  Object {
+    "style": "long",
+    "type": 3,
+    "value": "dateVal",
+  },
+  Object {
+    "type": 0,
+    "value": " at ",
+  },
+  Object {
+    "style": "short",
+    "type": 4,
+    "value": "timeVal",
+  },
+]
+`;
+
+exports[`number arg 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "I have ",
+  },
+  Object {
+    "style": null,
+    "type": 2,
+    "value": "numCats",
+  },
+  Object {
+    "type": 0,
+    "value": " cats.",
+  },
+]
+`;
+
+exports[`number arg with style 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "Almost ",
+  },
+  Object {
+    "style": "percent",
+    "type": 2,
+    "value": "pctBlack",
+  },
+  Object {
+    "type": 0,
+    "value": " of them are black.",
+  },
+]
+`;

--- a/packages/intl-messageformat-parser/test/__snapshots__/string_literal.test.ts.snap
+++ b/packages/intl-messageformat-parser/test/__snapshots__/string_literal.test.ts.snap
@@ -1,0 +1,74 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`does not start quoted text if apostrophe does not immediately precede a character 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "'aa'b'",
+  },
+]
+`;
+
+exports[`does not start quoted text if apostrophe does not immediately precede a character 2`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "I don't know",
+  },
+]
+`;
+
+exports[`starts quoted text if apostrophe immediately precedes a character 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "{a'b}",
+  },
+]
+`;
+
+exports[`starts quoted text if apostrophe immediately precedes a character 2`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "}a'b{",
+  },
+]
+`;
+
+exports[`starts quoted text if apostrophe immediately precedes a character 3`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "aaa{",
+  },
+]
+`;
+
+exports[`starts quoted text if apostrophe immediately precedes a character 4`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "aaa}",
+  },
+]
+`;
+
+exports[`treats double apostrophes as one apostrophe 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "a'b",
+  },
+]
+`;
+
+exports[`unescaped string literals 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "line1
+  line2",
+  },
+]
+`;

--- a/packages/intl-messageformat-parser/test/index.test.ts
+++ b/packages/intl-messageformat-parser/test/index.test.ts
@@ -15,19 +15,17 @@ function allTests(opts?: ParseOptions) {
     '{  num , number,percent  }',
     '{c, plural, =1 { {text} project} other { {text} projects}}',
     '{c, plural, =99 { {text} project} other { {text} projects}}',
-    '\\{',
-    '\\}',
-    '\\u003C',
+    `'{'`,
+    `'}'`,
     // Escaping "#" needs to be special-cased so it remains escaped so
     // the runtime doesn't replace it when in a `pluralFormat` option.
-    '\\#',
+    `'#'`,
     /**
      * @see http://userguide.icu-project.org/formatparse/messages#TOC-Quoting-Escaping
      * @see https://github.com/formatjs/formatjs/issues/97
      */
     "This '{isn''t}' obvious",
-    "''{name}''",
-    "''{name}''",
+    "'{name}'",
     'this is {count,plural,offset:1 one{{count, number} dog} other{{count, number} dogs}}'
   ].forEach(mess => {
     const ast = parse(mess, opts);

--- a/packages/intl-messageformat-parser/test/nested.test.ts
+++ b/packages/intl-messageformat-parser/test/nested.test.ts
@@ -1,0 +1,26 @@
+import { parse } from '../src/parser';
+
+test('plural arg nested inside select arg', () => {
+  expect(
+    parse(`\
+      {gender_of_host, select,
+        female {
+          {num_guests, plural, offset:1
+            =0 {{host} does not give a party.}
+            =1 {{host} invites {guest} to her party.}
+            =2 {{host} invites {guest} and one other person to her party.}
+            other {{host} invites {guest} and # other people to her party.}}}
+        male {
+          {num_guests, plural, offset:1
+            =0 {{host} does not give a party.}
+            =1 {{host} invites {guest} to his party.}
+            =2 {{host} invites {guest} and one other person to his party.}
+            other {{host} invites {guest} and # other people to his party.}}}
+        other {
+          {num_guests, plural, offset:1
+            =0 {{host} does not give a party.}
+            =1 {{host} invites {guest} to their party.}
+            =2 {{host} invites {guest} and one other person to their party.}
+            other {{host} invites {guest} and # other people to their party.}}}}`)
+  ).toMatchSnapshot();
+});

--- a/packages/intl-messageformat-parser/test/none_arg.test.ts
+++ b/packages/intl-messageformat-parser/test/none_arg.test.ts
@@ -1,0 +1,7 @@
+import { parse } from '../src/parser';
+
+test('trivial', () => {
+  expect(parse('{0}')).toMatchSnapshot();
+  expect(parse('{arg}')).toMatchSnapshot();
+  expect(parse('hello {name}')).toMatchSnapshot();
+});

--- a/packages/intl-messageformat-parser/test/plural_arg.test.ts
+++ b/packages/intl-messageformat-parser/test/plural_arg.test.ts
@@ -1,0 +1,29 @@
+import { parse } from '../src/parser';
+
+test('trivial', () => {
+  expect(
+    parse(`\
+      Cart: {itemCount} {itemCount, plural,
+        one {item}
+        other {items}
+      }`)
+  ).toMatchSnapshot();
+  expect(
+    parse(`\
+      You have {itemCount, plural,
+        =0 {no items}
+        one {1 item}
+        other {{itemCount} items}
+      }.`)
+  );
+});
+
+test('escaped nested message', () => {
+  expect(
+    parse(`\
+      {itemCount, plural,
+        one {item'}'}
+        other {items'}'}
+      }`)
+  ).toMatchSnapshot();
+});

--- a/packages/intl-messageformat-parser/test/select_arg.test.ts
+++ b/packages/intl-messageformat-parser/test/select_arg.test.ts
@@ -1,0 +1,24 @@
+import { parse } from '../src/parser';
+
+test('trivial', () => {
+  expect(
+    parse(`\
+      {gender, select,
+          male {He}
+          female {She}
+          other {They}
+      } will respond shortly.
+    `)
+  ).toMatchSnapshot();
+});
+
+test('nested arguments', () => {
+  expect(
+    parse(`\
+      {taxableArea, select,
+          yes {An additional {taxRate, number, percent} tax will be collected.}
+          other {No taxes apply.}
+      }
+    `)
+  ).toMatchSnapshot();
+});

--- a/packages/intl-messageformat-parser/test/simple_arg.test.ts
+++ b/packages/intl-messageformat-parser/test/simple_arg.test.ts
@@ -1,0 +1,27 @@
+import { parse } from '../src/parser';
+
+test('number arg', () => {
+  expect(parse('I have {numCats, number} cats.')).toMatchSnapshot();
+});
+
+test('number arg with style', () => {
+  expect(
+    parse('Almost {pctBlack, number, percent} of them are black.')
+  ).toMatchSnapshot();
+});
+
+test('date & time arg', () => {
+  expect(
+    parse(
+      'Your meeting is scheduled for the {dateVal, date} at {timeVal, time}'
+    )
+  ).toMatchSnapshot();
+});
+
+test('date & time arg with style', () => {
+  expect(
+    parse(
+      'Your meeting is scheduled for the {dateVal, date, long} at {timeVal, time, short}'
+    )
+  ).toMatchSnapshot();
+});

--- a/packages/intl-messageformat-parser/test/string_literal.test.ts
+++ b/packages/intl-messageformat-parser/test/string_literal.test.ts
@@ -1,0 +1,21 @@
+import { parse } from '../src/parser';
+
+test('unescaped string literals', () => {
+  expect(parse('line1\n  line2')).toMatchSnapshot();
+});
+
+test('treats double apostrophes as one apostrophe', () => {
+  expect(parse(`a''b`)).toMatchSnapshot();
+});
+
+test('starts quoted text if apostrophe immediately precedes a character', () => {
+  expect(parse(`'{a''b}'`)).toMatchSnapshot();
+  expect(parse(`'}a''b{'`)).toMatchSnapshot();
+  expect(parse(`aaa'{'`)).toMatchSnapshot();
+  expect(parse(`aaa'}'`)).toMatchSnapshot();
+});
+
+test('does not start quoted text if apostrophe does not immediately precede a character', () => {
+  expect(parse(`'aa''b'`)).toMatchSnapshot();
+  expect(parse(`I don't know`)).toMatchSnapshot();
+});

--- a/packages/intl-messageformat/.gitignore
+++ b/packages/intl-messageformat/.gitignore
@@ -5,3 +5,4 @@ tests/*.js*
 core.js
 core.d.ts
 !tests/setup.js
+.rpt2_cache

--- a/packages/intl-messageformat/src/core.ts
+++ b/packages/intl-messageformat/src/core.ts
@@ -44,6 +44,7 @@ function resolveLocale(locales: string | string[]): string {
   }
 }
 
+// TODO(skeleton): add skeleton support
 function prewarmFormatters(
   els: MessageFormatElement[],
   locales: string | string[],
@@ -57,25 +58,28 @@ function prewarmFormatters(
       // nested pattern structure. The choosing of the option to use is
       // abstracted-by and delegated-to the part helper object.
       if (isDateElement(el)) {
-        const style = el.style ? formats.date[el.style] : undefined;
-        return formatters.getDateTimeFormat(locales, style);
+        const style =
+          typeof el.style === 'string' ? formats.date[el.style] : undefined;
+        formatters.getDateTimeFormat(locales, style);
       }
       if (isTimeElement(el)) {
-        const style = el.style ? formats.time[el.style] : undefined;
-        return formatters.getDateTimeFormat(locales, style);
+        const style =
+          typeof el.style === 'string' ? formats.time[el.style] : undefined;
+        formatters.getDateTimeFormat(locales, style);
       }
       if (isNumberElement(el)) {
-        const style = el.style ? formats.number[el.style] : undefined;
-        return formatters.getNumberFormat(locales, style);
+        const style =
+          typeof el.style === 'string' ? formats.number[el.style] : undefined;
+        formatters.getNumberFormat(locales, style);
       }
       if (isSelectElement(el)) {
-        return Object.keys(el.options).forEach(id =>
+        Object.keys(el.options).forEach(id =>
           prewarmFormatters(el.options[id].value, locales, formatters, formats)
         );
       }
       if (isPluralElement(el)) {
         formatters.getPluralRules(locales, { type: el.pluralType });
-        return Object.keys(el.options).forEach(id =>
+        Object.keys(el.options).forEach(id =>
           prewarmFormatters(el.options[id].value, locales, formatters, formats)
         );
       }

--- a/packages/intl-messageformat/src/formatters.ts
+++ b/packages/intl-messageformat/src/formatters.ts
@@ -84,6 +84,7 @@ function mergeLiteral(parts: MessageFormatPart[]): MessageFormatPart[] {
   );
 }
 
+// TODO(skeleton): add skeleton support
 export function formatToParts(
   els: MessageFormatElement[],
   locales: string | string[],
@@ -144,7 +145,8 @@ export function formatToParts(
     // nested pattern structure. The choosing of the option to use is
     // abstracted-by and delegated-to the part helper object.
     if (isDateElement(el)) {
-      const style = el.style ? formats.date[el.style] : undefined;
+      const style =
+        typeof el.style === 'string' ? formats.date[el.style] : undefined;
       result.push({
         type: PART_TYPE.literal,
         value: formatters
@@ -154,7 +156,8 @@ export function formatToParts(
       continue;
     }
     if (isTimeElement(el)) {
-      const style = el.style ? formats.time[el.style] : undefined;
+      const style =
+        typeof el.style === 'string' ? formats.time[el.style] : undefined;
       result.push({
         type: PART_TYPE.literal,
         value: formatters
@@ -164,7 +167,8 @@ export function formatToParts(
       continue;
     }
     if (isNumberElement(el)) {
-      const style = el.style ? formats.number[el.style] : undefined;
+      const style =
+        typeof el.style === 'string' ? formats.number[el.style] : undefined;
       result.push({
         type: PART_TYPE.literal,
         value: formatters


### PR DESCRIPTION
> A literal apostrophe is represented by either a single or a double apostrophe pattern character. Within a MessageFormat pattern, a single apostrophe only starts quoted literal text if it immediately precedes a curly brace `{}`.

This PR:
- Enforces that the opened quote has to be closed.
- Removes the backslash escape sequence that does not exist in ICU4J.
- Make argument identifier / plural or select rule selector compatible with ICU4J's syntax.