### PR TITLE
fix(intl-messageformat-parser): argStyleText can contain syntax characters and quoted string now

### DIFF
--- a/packages/intl-messageformat-parser/src/parser.pegjs
+++ b/packages/intl-messageformat-parser/src/parser.pegjs
@@ -77,7 +77,7 @@ numberSkeleton
 
 numberArgStyle
     = '::' skeleton:numberSkeleton { return skeleton; }
-    / keyword
+    / style:messageText { return style.replace(/\s*$/, ''); }
 
 numberFormatElement
     = '{' _ value:argName _ ',' _ type:'number' _ style:(',' _ numberArgStyle)? _ '}' {
@@ -104,7 +104,7 @@ dateOrTimeSkeleton
 
 dateOrTimeArgStyle
     = '::' skeleton:dateOrTimeSkeleton { return skeleton; }
-    / keyword
+    / style:messageText { return style.replace(/\s*$/, ''); }
 
 dateOrTimeFormatElement
     = '{' _ value:argName _ ',' _ type:('date' / 'time') _ style:(',' _ dateOrTimeArgStyle)? _ '}' {

--- a/packages/intl-messageformat-parser/src/printer.ts
+++ b/packages/intl-messageformat-parser/src/printer.ts
@@ -26,15 +26,6 @@ import {
   NumberSkeletonToken
 } from './types';
 
-const ESCAPED_CHARS: Record<string, string> = {
-  '\\': '\\\\',
-  '\\#': '\\#',
-  '{': '\\{',
-  '}': '\\}'
-};
-
-const ESAPE_CHARS_REGEXP = /\\#|[{}\\]/g;
-
 export function printAST(ast: MessageFormatElement[]): string {
   let printedNodes = ast.map(el => {
     if (isLiteralElement(el)) {
@@ -61,7 +52,7 @@ export function printAST(ast: MessageFormatElement[]): string {
 }
 
 function printEscapedMessage(message: string): string {
-  return message.replace(ESAPE_CHARS_REGEXP, char => ESCAPED_CHARS[char]);
+  return message.replace(/([{}](?:.*[{}])?)/su, `'$1'`);
 }
 
 function printLiteralElement({ value }: LiteralElement) {
@@ -89,7 +80,7 @@ function printNumberSkeletonToken(token: NumberSkeletonToken): string {
 
 function printArgumentStyle(style: string | Skeleton) {
   if (typeof style === 'string') {
-    return style;
+    return printEscapedMessage(style);
   } else if (style.type === SKELETON_TYPE.date) {
     return `::${printEscapedMessage(style.pattern)}`;
   } else {

--- a/packages/intl-messageformat-parser/test/__snapshots__/arg_style.test.ts.snap
+++ b/packages/intl-messageformat-parser/test/__snapshots__/arg_style.test.ts.snap
@@ -1,0 +1,97 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`argStyleText test case: "{0,date,y-M-d HH:mm:ss zzzz}" 1`] = `
+Array [
+  Object {
+    "style": "y-M-d HH:mm:ss zzzz",
+    "type": 3,
+    "value": "0",
+  },
+]
+`;
+
+exports[`argStyleText test case: "{0,date,y-M-d HH:mm:ss zzzz}" 2`] = `"{0, date, y-M-d HH:mm:ss zzzz}"`;
+
+exports[`argStyleText test case: "{0,date,y-M-d HH:mm:ss}" 1`] = `
+Array [
+  Object {
+    "style": "y-M-d HH:mm:ss",
+    "type": 3,
+    "value": "0",
+  },
+]
+`;
+
+exports[`argStyleText test case: "{0,date,y-M-d HH:mm:ss}" 2`] = `"{0, date, y-M-d HH:mm:ss}"`;
+
+exports[`argStyleText test case: "{0,date,y-M-d,HH:mm:ss,zzzz}" 1`] = `
+Array [
+  Object {
+    "style": "y-M-d,HH:mm:ss,zzzz",
+    "type": 3,
+    "value": "0",
+  },
+]
+`;
+
+exports[`argStyleText test case: "{0,date,y-M-d,HH:mm:ss,zzzz}" 2`] = `"{0, date, y-M-d,HH:mm:ss,zzzz}"`;
+
+exports[`argStyleText test case: "{0,number,''}" 1`] = `
+Array [
+  Object {
+    "style": "'",
+    "type": 2,
+    "value": "0",
+  },
+]
+`;
+
+exports[`argStyleText test case: "{0,number,''}" 2`] = `"{0, number, '}"`;
+
+exports[`argStyleText test case: "{0,number,'{}'}" 1`] = `
+Array [
+  Object {
+    "style": "{}",
+    "type": 2,
+    "value": "0",
+  },
+]
+`;
+
+exports[`argStyleText test case: "{0,number,'{}'}" 2`] = `"{0, number, '{}'}"`;
+
+exports[`argStyleText test case: "{0,number,y-M-d HH:mm:ss zzzz}" 1`] = `
+Array [
+  Object {
+    "style": "y-M-d HH:mm:ss zzzz",
+    "type": 2,
+    "value": "0",
+  },
+]
+`;
+
+exports[`argStyleText test case: "{0,number,y-M-d HH:mm:ss zzzz}" 2`] = `"{0, number, y-M-d HH:mm:ss zzzz}"`;
+
+exports[`argStyleText test case: "{0,number,y-M-d HH:mm:ss}" 1`] = `
+Array [
+  Object {
+    "style": "y-M-d HH:mm:ss",
+    "type": 2,
+    "value": "0",
+  },
+]
+`;
+
+exports[`argStyleText test case: "{0,number,y-M-d HH:mm:ss}" 2`] = `"{0, number, y-M-d HH:mm:ss}"`;
+
+exports[`argStyleText test case: "{0,number,y-M-d,HH:mm:ss,zzzz}" 1`] = `
+Array [
+  Object {
+    "style": "y-M-d,HH:mm:ss,zzzz",
+    "type": 2,
+    "value": "0",
+  },
+]
+`;
+
+exports[`argStyleText test case: "{0,number,y-M-d,HH:mm:ss,zzzz}" 2`] = `"{0, number, y-M-d,HH:mm:ss,zzzz}"`;

--- a/packages/intl-messageformat-parser/test/__snapshots__/index.test.ts.snap
+++ b/packages/intl-messageformat-parser/test/__snapshots__/index.test.ts.snap
@@ -555,11 +555,11 @@ exports[`parse() can print AST from '   some random test   ' 1`] = `"   some ran
 
 exports[`parse() can print AST from ''#'' 1`] = `"'#'"`;
 
-exports[`parse() can print AST from ''{'' 1`] = `"\\\\{"`;
+exports[`parse() can print AST from ''{'' 1`] = `"'{'"`;
 
-exports[`parse() can print AST from ''{name}'' 1`] = `"\\\\{name\\\\}"`;
+exports[`parse() can print AST from ''{name}'' 1`] = `"'{name}'"`;
 
-exports[`parse() can print AST from ''}'' 1`] = `"\\\\}"`;
+exports[`parse() can print AST from ''}'' 1`] = `"'}'"`;
 
 exports[`parse() can print AST from '{  num , number,percent  }' 1`] = `"{num, number, percent}"`;
 
@@ -585,7 +585,7 @@ exports[`parse() can print AST from 'Hello, World!' 1`] = `"Hello, World!"`;
 
 exports[`parse() can print AST from 'My name is {FIRST} {LAST}, age {age, number}, time {time, time}, date {date, date}.' 1`] = `"My name is {FIRST} {LAST}, age {age, number}, time {time, time}, date {date, date}."`;
 
-exports[`parse() can print AST from 'This '{isn''t}' obvious' 1`] = `"This \\\\{isn't\\\\} obvious"`;
+exports[`parse() can print AST from 'This '{isn''t}' obvious' 1`] = `"This '{isn't}' obvious"`;
 
 exports[`parse() can print AST from 'this is {count,plural,offset:1 one{{count, number} dog} other{{count, number} dogs}}' 1`] = `"this is {count,plural,offset:1 one{{count, number} dog} other{{count, number} dogs}}"`;
 
@@ -1144,11 +1144,11 @@ exports[`parse({ captureLocation: true }) can print AST from '   some random tes
 
 exports[`parse({ captureLocation: true }) can print AST from ''#'' 1`] = `"'#'"`;
 
-exports[`parse({ captureLocation: true }) can print AST from ''{'' 1`] = `"\\\\{"`;
+exports[`parse({ captureLocation: true }) can print AST from ''{'' 1`] = `"'{'"`;
 
-exports[`parse({ captureLocation: true }) can print AST from ''{name}'' 1`] = `"\\\\{name\\\\}"`;
+exports[`parse({ captureLocation: true }) can print AST from ''{name}'' 1`] = `"'{name}'"`;
 
-exports[`parse({ captureLocation: true }) can print AST from ''}'' 1`] = `"\\\\}"`;
+exports[`parse({ captureLocation: true }) can print AST from ''}'' 1`] = `"'}'"`;
 
 exports[`parse({ captureLocation: true }) can print AST from '{  num , number,percent  }' 1`] = `"{num, number, percent}"`;
 
@@ -1174,6 +1174,6 @@ exports[`parse({ captureLocation: true }) can print AST from 'Hello, World!' 1`]
 
 exports[`parse({ captureLocation: true }) can print AST from 'My name is {FIRST} {LAST}, age {age, number}, time {time, time}, date {date, date}.' 1`] = `"My name is {FIRST} {LAST}, age {age, number}, time {time, time}, date {date, date}."`;
 
-exports[`parse({ captureLocation: true }) can print AST from 'This '{isn''t}' obvious' 1`] = `"This \\\\{isn't\\\\} obvious"`;
+exports[`parse({ captureLocation: true }) can print AST from 'This '{isn''t}' obvious' 1`] = `"This '{isn't}' obvious"`;
 
 exports[`parse({ captureLocation: true }) can print AST from 'this is {count,plural,offset:1 one{{count, number} dog} other{{count, number} dogs}}' 1`] = `"this is {count,plural,offset:1 one{{count, number} dog} other{{count, number} dogs}}"`;

--- a/packages/intl-messageformat-parser/test/arg_style.test.ts
+++ b/packages/intl-messageformat-parser/test/arg_style.test.ts
@@ -1,0 +1,17 @@
+import { parse } from '../src/parser';
+import { printAST } from '../src/printer';
+
+test.each([
+  `{0,date,y-M-d HH:mm:ss}`,
+  `{0,number,y-M-d HH:mm:ss}`,
+  `{0,date,y-M-d HH:mm:ss zzzz}`,
+  `{0,number,y-M-d HH:mm:ss zzzz}`,
+  `{0,date,y-M-d,HH:mm:ss,zzzz}`,
+  `{0,number,y-M-d,HH:mm:ss,zzzz}`,
+  `{0,number,'{}'}`,
+  `{0,number,''}`
+])('argStyleText test case: %p', testCase => {
+  const ast = parse(testCase);
+  expect(ast).toMatchSnapshot();
+  expect(printAST(ast)).toMatchSnapshot();
+});

--- a/packages/intl-messageformat/tests/index.ts
+++ b/packages/intl-messageformat/tests/index.ts
@@ -415,7 +415,7 @@ describe('IntlMessageFormat', function() {
       it('should fail when the argument in the pattern is not provided', function() {
         expect(msg.format).to.throw(
           Error,
-          /The intl string context variable 'STATE' was not provided to the string '{STATE}'/
+          /The intl string context variable "STATE" was not provided to the string "{STATE}"/
         );
       });
 
@@ -426,7 +426,7 @@ describe('IntlMessageFormat', function() {
 
         expect(formatWithValueNameTypo).to.throw(
           Error,
-          /The intl string context variable 'STATE' was not provided to the string '{STATE}'/
+          /The intl string context variable "STATE" was not provided to the string "{STATE}"/
         );
       });
 
@@ -446,7 +446,7 @@ describe('IntlMessageFormat', function() {
 
         expect(formatWithMissingValue).to.throw(
           Error,
-          /The intl string context variable 'ST1ATE' was not provided to the string '{ST1ATE}'/
+          /The intl string context variable "ST1ATE" was not provided to the string "{ST1ATE}"/
         );
       });
 
@@ -457,7 +457,7 @@ describe('IntlMessageFormat', function() {
 
         expect(formatWithMissingValue).to.throw(
           Error,
-          /The intl string context variable 'ST1ATE' was not provided to the string '{ST1ATE}'/
+          /The intl string context variable "ST1ATE" was not provided to the string "{ST1ATE}"/
         );
       });
 


### PR DESCRIPTION
- Fixes #135
- Also fix printer so they properly print AST that contains special characters. In other words, `printAST(parse(message))` should spit the string that is semantically equivalence of `message`.