### PR TITLE
fix(intl-messageformat-parser): make date time skeleton compatible with ICU

### DIFF
--- a/packages/intl-messageformat-parser/build.js
+++ b/packages/intl-messageformat-parser/build.js
@@ -22,7 +22,7 @@ import {
     PluralElement,
     PluralOrSelectOption,
     NumberSkeleton,
-    DateSkeleton,
+    DateTimeSkeleton,
     SKELETON_TYPE,
     TYPE,
 } from './types'`
@@ -48,9 +48,9 @@ import {
     selectOption: 'PluralOrSelectOption',
     pluralOption: 'PluralOrSelectOption',
     numberSkeleton: 'NumberSkeleton',
-    dateOrTimeSkeleton: 'DateSkeleton',
+    dateTimeSkeleton: 'DateTimeSkeleton',
     numberArgStyle: 'string | NumberSkeleton',
-    dateOrTimeArgStyle: 'string | DateSkeleton',
+    dateTimeArgStyle: 'string | DateTimeSkeleton',
     simpleFormatElement: `
 | NumberElement
 | DateElement

--- a/packages/intl-messageformat-parser/src/parser.pegjs
+++ b/packages/intl-messageformat-parser/src/parser.pegjs
@@ -89,21 +89,24 @@ numberFormatElement
         };
     }
 
+dateTimeSkeletonLiteral = "'" (doubleApostrophes / [^'])+ "'" / (doubleApostrophes / [^a-zA-Z'{}])+
+dateTimeSkeletonPattern = [a-zA-Z]+
+
 // See also:
+// - http://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table
 // - http://cldr.unicode.org/translation/date-time-patterns
 // - http://www.icu-project.org/apiref/icu4j/com/ibm/icu/text/SimpleDateFormat.html
-// Here we implement the ICU >= 4.8 quoting behavior.
-dateOrTimeSkeleton
-    = pattern:messageText {
+dateTimeSkeleton
+    = pattern:$(dateTimeSkeletonLiteral / dateTimeSkeletonPattern)+ {
         return {
-            type: SKELETON_TYPE.date,
+            type: SKELETON_TYPE.dateTime,
             pattern,
             ...insertLocation(),
         }
     }
 
 dateOrTimeArgStyle
-    = '::' skeleton:dateOrTimeSkeleton { return skeleton; }
+    = '::' skeleton:dateTimeSkeleton { return skeleton; }
     / style:messageText { return style.replace(/\s*$/, ''); }
 
 dateOrTimeFormatElement

--- a/packages/intl-messageformat-parser/src/printer.ts
+++ b/packages/intl-messageformat-parser/src/printer.ts
@@ -23,7 +23,8 @@ import {
   TYPE,
   Skeleton,
   SKELETON_TYPE,
-  NumberSkeletonToken
+  NumberSkeletonToken,
+  DateTimeSkeleton
 } from './types';
 
 export function printAST(ast: MessageFormatElement[]): string {
@@ -81,11 +82,15 @@ function printNumberSkeletonToken(token: NumberSkeletonToken): string {
 function printArgumentStyle(style: string | Skeleton) {
   if (typeof style === 'string') {
     return printEscapedMessage(style);
-  } else if (style.type === SKELETON_TYPE.date) {
-    return `::${printEscapedMessage(style.pattern)}`;
+  } else if (style.type === SKELETON_TYPE.dateTime) {
+    return `::${printDateTimeSkeleton(style)}`;
   } else {
     return `::${style.tokens.map(printNumberSkeletonToken).join(' ')}`;
   }
+}
+
+export function printDateTimeSkeleton(style: DateTimeSkeleton): string {
+  return style.pattern;
 }
 
 function printSelectElement(el: SelectElement) {

--- a/packages/intl-messageformat-parser/src/types.ts
+++ b/packages/intl-messageformat-parser/src/types.ts
@@ -31,7 +31,7 @@ export enum TYPE {
 
 export const enum SKELETON_TYPE {
   number,
-  date
+  dateTime
 }
 
 export interface LocationDetails {
@@ -59,8 +59,8 @@ export interface SimpleFormatElement<T extends TYPE, S extends Skeleton>
 }
 
 export type NumberElement = SimpleFormatElement<TYPE.number, NumberSkeleton>;
-export type DateElement = SimpleFormatElement<TYPE.date, DateSkeleton>;
-export type TimeElement = SimpleFormatElement<TYPE.time, DateSkeleton>;
+export type DateElement = SimpleFormatElement<TYPE.date, DateTimeSkeleton>;
+export type TimeElement = SimpleFormatElement<TYPE.time, DateTimeSkeleton>;
 
 export interface SelectOption {
   id: string;
@@ -112,13 +112,13 @@ export interface NumberSkeleton {
   location?: Location;
 }
 
-export interface DateSkeleton {
-  type: SKELETON_TYPE.date;
+export interface DateTimeSkeleton {
+  type: SKELETON_TYPE.dateTime;
   pattern: string;
   location?: Location;
 }
 
-export type Skeleton = NumberSkeleton | DateSkeleton;
+export type Skeleton = NumberSkeleton | DateTimeSkeleton;
 
 /**
  * Type Guards
@@ -151,8 +151,8 @@ export function isPluralElement(el: MessageFormatElement): el is PluralElement {
 export function isNumberSkeleton(el: Skeleton): el is NumberSkeleton {
   return el.type === SKELETON_TYPE.number;
 }
-export function isDateSkeleton(el: Skeleton): el is DateSkeleton {
-  return el.type === SKELETON_TYPE.date;
+export function isDateTimeSkeleton(el: Skeleton): el is DateTimeSkeleton {
+  return el.type === SKELETON_TYPE.dateTime;
 }
 
 export function createLiteralElement(value: string): LiteralElement {

--- a/packages/intl-messageformat-parser/test/__snapshots__/date_skeleton.test.ts.snap
+++ b/packages/intl-messageformat-parser/test/__snapshots__/date_skeleton.test.ts.snap
@@ -1,10 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`case: "EEE, MMM d, 'yy" 1`] = `
+exports[`case: "" 1`] = `
+Array [
+  Object {
+    "style": "::",
+    "type": 3,
+    "value": "0",
+  },
+]
+`;
+
+exports[`case: "" 2`] = `"{0, date, ::}"`;
+
+exports[`case: "EEE, MMM d, ''yy" 1`] = `
 Array [
   Object {
     "style": Object {
-      "pattern": "EEE, MMM d, 'yy",
+      "pattern": "EEE, MMM d, ''yy",
       "type": 1,
     },
     "type": 3,
@@ -13,7 +25,7 @@ Array [
 ]
 `;
 
-exports[`case: "EEE, MMM d, 'yy" 2`] = `"{0, date, ::EEE, MMM d, 'yy}"`;
+exports[`case: "EEE, MMM d, ''yy" 2`] = `"{0, date, ::EEE, MMM d, ''yy}"`;
 
 exports[`case: "h:mm a" 1`] = `
 Array [
@@ -30,11 +42,11 @@ Array [
 
 exports[`case: "h:mm a" 2`] = `"{0, date, ::h:mm a}"`;
 
-exports[`case: "yyyy.MM.dd G at HH:mm:ss vvvv" 1`] = `
+exports[`case: "yyyy.MM.dd G 'at' HH:mm:ss vvvv" 1`] = `
 Array [
   Object {
     "style": Object {
-      "pattern": "yyyy.MM.dd G at HH:mm:ss vvvv",
+      "pattern": "yyyy.MM.dd G 'at' HH:mm:ss vvvv",
       "type": 1,
     },
     "type": 3,
@@ -43,4 +55,4 @@ Array [
 ]
 `;
 
-exports[`case: "yyyy.MM.dd G at HH:mm:ss vvvv" 2`] = `"{0, date, ::yyyy.MM.dd G at HH:mm:ss vvvv}"`;
+exports[`case: "yyyy.MM.dd G 'at' HH:mm:ss vvvv" 2`] = `"{0, date, ::yyyy.MM.dd G 'at' HH:mm:ss vvvv}"`;

--- a/packages/intl-messageformat-parser/test/date_skeleton.test.ts
+++ b/packages/intl-messageformat-parser/test/date_skeleton.test.ts
@@ -1,11 +1,13 @@
 import { parse } from '../src/parser';
 import { printAST } from '../src/printer';
 
-test.each([`yyyy.MM.dd G at HH:mm:ss vvvv`, `EEE, MMM d, 'yy`, `h:mm a`])(
-  'case: %p',
-  skeleton => {
-    const ast = parse(`{0, date, ::${skeleton}}`);
-    expect(ast).toMatchSnapshot();
-    expect(printAST(ast)).toMatchSnapshot();
-  }
-);
+test.each([
+  `yyyy.MM.dd G 'at' HH:mm:ss vvvv`,
+  `EEE, MMM d, ''yy`,
+  `h:mm a`,
+  ``
+])('case: %p', skeleton => {
+  const ast = parse(`{0, date, ::${skeleton}}`);
+  expect(ast).toMatchSnapshot();
+  expect(printAST(ast)).toMatchSnapshot();
+});


### PR DESCRIPTION
This diff makes breaking changes to intl-messageformat-parser's AST.

Now the date time skeleton is compatible with ICU4J in that:
- `[a-z][A-Z]` are recognized as pattern characters, whereas others are literal.
- You can use single quote to quote `[a-z][A-Z]` to treat them as literals.

The output AST is renamed to DateTimeSkeleton and contains the skeleton pattern **verbatim**.