### PR TITLE
Fix enforceDefaultMessage for JSX elements

### DIFF
--- a/packages/babel-plugin-react-intl/src/index.ts
+++ b/packages/babel-plugin-react-intl/src/index.ts
@@ -443,7 +443,7 @@ export default declare((api: any) => {
           // be extracted only if a `defaultMessage` prop exists and
           // `enforceDefaultMessage` is `true`.
           if (
-            enforceDefaultMessage === false ||
+            enforceDefaultMessage === true ||
             descriptorPath.defaultMessage
           ) {
             // Evaluate the Message Descriptor values in a JSX


### PR DESCRIPTION
`enforceDefaultMessage` set to  `true` and `<FormattedMessage {...descriptor} />` was not working