### PR TITLE
fix(babel-plugin-react-intl): check if id is present in JSX

### DIFF
--- a/packages/babel-plugin-react-intl/src/index.ts
+++ b/packages/babel-plugin-react-intl/src/index.ts
@@ -437,14 +437,13 @@ export default declare((api: any) => {
           // In order for a default message to be extracted when
           // declaring a JSX element, it must be done with standard
           // `key=value` attributes. But it's completely valid to
-          // write `<FormattedMessage {...descriptor} />` or
-          // `<FormattedMessage id={dynamicId} />`, because it will be
+          // write `<FormattedMessage {...descriptor} />`, because it will be
           // skipped here and extracted elsewhere. The descriptor will
-          // be extracted only if a `defaultMessage` prop exists and
-          // `enforceDefaultMessage` is `true`.
+          // be extracted only (storeMessage) if a `defaultMessage` prop
+          // exists and `enforceDefaultMessage` is `true`.
           if (
-            enforceDefaultMessage === false ||
-            descriptorPath.defaultMessage
+            descriptorPath.id &&
+            (enforceDefaultMessage === false || descriptorPath.defaultMessage)
           ) {
             // Evaluate the Message Descriptor values in a JSX
             // context, then store it.

--- a/packages/babel-plugin-react-intl/test/fixtures/enforceDefaultMessage/actual.js
+++ b/packages/babel-plugin-react-intl/test/fixtures/enforceDefaultMessage/actual.js
@@ -7,8 +7,15 @@ defineMessages({
   },
 })
 
+const testMessage = { id: 'TRANSLATION_KEY2' };
+
 export default class Foo extends Component {
   render() {
-    return <FormattedMessage id="foo.bar.baz" />;
+    return (
+      <>
+        <FormattedMessage id="foo.bar.baz" />
+        <FormattedMessage {...testMessage} />
+      </>
+    );
   }
 }


### PR DESCRIPTION
<FormattedMessage {...descriptor} /> was not working ([React Intl] Message Descriptors require an `id` and `defaultMessage` )