### PR TITLE
chore(intl-messageformat): Add DOMParser polyfill in README

### DIFF
--- a/packages/intl-messageformat/README.md
+++ b/packages/intl-messageformat/README.md
@@ -183,6 +183,8 @@ This is not meant to be a full-fledged method to embed HTML, but rather to tag s
 
 - List of self-closing tags is defined [here](https://html.spec.whatwg.org/multipage/syntax.html#void-elements).
 
+If you don't have `DOMParser` available in your environment (e.g. Node.js), you need to add a polyfill. One of the packages that provides such a polyfill is [xmldom](https://www.npmjs.com/package/xmldom).
+
 ### User Defined Formats
 
 Define custom format styles is useful you need supply a set of options to the underlying formatter; e.g., outputting a number in USD:


### PR DESCRIPTION
I had an issue when running react-intl server side with strings that contained html tags.

I'm not sure where it would make more sense to add this mention, but I feel like it would be nice to mention which polyfill to use somewhere in formatjs. Not sure if xmldom is the best alternative either. I don't really have experience in this field, but it seems to be heavily relied on by the ecosystem.

Thanks for the great lib anyway! :wave: 