### PR TITLE
feat(@formatjs/intl-utils): add PartitionPattern abstract operation

### DIFF
--- a/packages/intl-utils/src/index.ts
+++ b/packages/intl-utils/src/index.ts
@@ -6,6 +6,9 @@ export {
   getParentLocalesByLang,
   setInternalSlot,
   getInternalSlot,
+  partitionPattern,
+  isLiteralPart,
+  LiteralPart,
 } from './polyfill-utils';
 export {
   createResolveLocale,

--- a/packages/intl-utils/tests/polyfill-utils.ts
+++ b/packages/intl-utils/tests/polyfill-utils.ts
@@ -1,0 +1,19 @@
+import {partitionPattern} from '../src/polyfill-utils';
+describe('polyfill-utils', function() {
+  it('should partition pattern correctly', function() {
+    expect(partitionPattern('AA{0}BB')).to.deep.equal([
+      {
+        type: 'literal',
+        value: 'AA',
+      },
+      {
+        type: '0',
+        value: undefined,
+      },
+      {
+        type: 'literal',
+        value: 'BB',
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
fix(@formatjs/intl-relativetimeformat): Use PartitionPattern abstract operation when parsing pattern so we're spec-compliant (pending https://github.com/tc39/proposal-intl-relative-time/pull/114)
fix(@formatjs/intl-listformat): Use PartitionPattern abstract operation when parsing pattern so we're compliant w/ latest version of spec