### PR TITLE
Fix correct display of value/unit

### DIFF
--- a/packages/intl-utils/src/diff.ts
+++ b/packages/intl-utils/src/diff.ts
@@ -56,22 +56,22 @@ export function selectUnit(
   const toDate = new Date(to);
 
   const years = fromDate.getFullYear() - toDate.getFullYear();
-  if (Math.round(Math.abs(years)) > 0) {
+  const months = years * 12 + fromDate.getMonth() - toDate.getMonth();
+  if (Math.round(Math.abs(months)) > 0 && Math.round(Math.abs(months)) < 12) {
+    return {
+      value: Math.round(months),
+      unit: 'month',
+    };
+  }
+
+  if (Math.round(Math.abs(months)) >= 12 && Math.round(Math.abs(years)) > 0) {
     return {
       value: Math.round(years),
       unit: 'year',
     };
   }
 
-  const months = years * 12 + fromDate.getMonth() - toDate.getMonth();
-  if (Math.round(Math.abs(months)) > 0) {
-    return {
-      value: Math.round(months),
-      unit: 'month',
-    };
-  }
   const weeks = secs / SECS_PER_WEEK;
-
   return {
     value: Math.round(weeks),
     unit: 'week',


### PR DESCRIPTION
"1 year ago" is displayed when two close dates are in different years. e.g:

- current behaviour:
12/12/2019 - 12/01/2020 display "1 year ago"
30/12/2019 - 12/01/2020 display "1 year ago"

- expected:
12/12/2019 - 12/01/2020 display "1 month ago"
30/12/2019 - 12/01/2020 display "2 weeks ago"