### PR TITLE
feat(intl-unified-numberformat): fix some 262 test cases

### DIFF
--- a/packages/intl-unified-numberformat/package.json
+++ b/packages/intl-unified-numberformat/package.json
@@ -26,7 +26,8 @@
   ],
   "devDependencies": {
     "@formatjs/intl-pluralrules": "^1.5.0",
-    "formatjs-extract-cldr-data": "^10.0.4"
+    "formatjs-extract-cldr-data": "^10.0.4",
+    "chalk": "^2.0.0"
   },
   "dependencies": {
     "@formatjs/intl-utils": "^2.0.4",

--- a/packages/intl-unified-numberformat/tests/runner.ts
+++ b/packages/intl-unified-numberformat/tests/runner.ts
@@ -1,6 +1,7 @@
 import {spawnSync} from 'child_process';
 import {resolve} from 'path';
 import {cpus} from 'os';
+import chalk from 'chalk';
 
 if (process.version.startsWith('v13')) {
   console.log(
@@ -86,10 +87,10 @@ if (!json) {
 const failedTests = json.filter(r => !r.result.pass);
 for (const t of json) {
   if (t.result.pass) {
-    console.log(`✓ ${t.attrs.description}`);
+    console.log(`${chalk.green('✓')} ${t.attrs.description}`);
   } else {
     console.log('\n\n');
-    console.log(`🗴 ${t.attrs.description}`);
+    console.log(`${chalk.red('✗')} ${t.attrs.description}`);
     console.log('\t', t.result.message);
     console.log('\t', resolve(__dirname, '..', t.file));
     console.log('\n\n');

--- a/packages/intl-unified-numberformat/tests/runner.ts
+++ b/packages/intl-unified-numberformat/tests/runner.ts
@@ -28,23 +28,22 @@ interface TestResult {
     pass: boolean;
     message?: string;
   };
+  rawResult: {
+    stderr: string;
+    stdout: string;
+    error?: Error;
+  };
 }
 const excludedTests = [
-  'bound-to-numberformat-instance', // Need to fix `new`
-  'builtin', // Need to fix `new`
-  'constructor-locales-arraylike', // This checks that we can handle {length: 1, 0: 'foo'} array-like
+  'builtin', // Built-in functions cannot have `prototype` property.
   'constructor-locales-hasproperty', // This checks that we only iterate once...
-  'constructor-locales-string', // To pass this we gotta ditch class bc it's called w/o `new`
   'constructor-numberingSystem-order', // This test might be wrong
   'constructor-options-throwing-getters', // This test might be wrong
   'constructor-unit', // This test might be wrong, this throws if `unit` is being accessed when style is not `unit`, but spec doesn't prohibit that
-  'currency-digits', // Need to fix `new`
-  'default-minimum-singificant-digits', // Need to fix `new`
   'format-fraction-digits-precision', // oh boi...
   'legacy-regexp-statics-not-modified', // TODO
   'numbering-system-options', // TODO
   'proto-from-ctor-realm', // Bc of Realm support
-  'this-value-ignored', // Need to fix `new`
   'units', // We haven't monkey-patched `toLocaleString` (prototype/format/units.js)
 ];
 const PATTERN = resolve(
@@ -55,7 +54,7 @@ const PATTERN = resolve(
 );
 const args = [
   '--reporter-keys',
-  'file,attrs,result',
+  'file,attrs,result,rawResult',
   '-t',
   String(cpus().length - 1),
   '--prelude',
@@ -91,7 +90,8 @@ for (const t of json) {
   } else {
     console.log('\n\n');
     console.log(`${chalk.red('✗')} ${t.attrs.description}`);
-    console.log('\t', t.result.message);
+    console.log(t.rawResult.stdout);
+    console.log(chalk.red(t.rawResult.stderr));
     console.log('\t', resolve(__dirname, '..', t.file));
     console.log('\n\n');
   }

--- a/packages/intl-utils/src/polyfill-utils.ts
+++ b/packages/intl-utils/src/polyfill-utils.ts
@@ -144,7 +144,7 @@ export function setMultiInternalSlots<
   pl: Instance,
   props: Pick<NonNullable<Internal>, K>
 ) {
-  for (const k in props) {
+  for (const k of Object.keys(props) as K[]) {
     setInternalSlot(map, pl, k, props[k]);
   }
 }


### PR DESCRIPTION
- refactors UnifiedNumberFormat to not use ES classes because there is no workaround for calling constructor without `new` with ES class.
- fixed some tests where unicode extension is part of the locale, which results in a locale data dictionary lookup failure. I was able to delete some skipped tests as a result.
- Fixed bugs in `toRawPrecision`.
- modified 262 test runner with some color and force showing stack traces to help with debugging.

So we have only 4 (actually 2 because each is run twice) test failures excluding the excluded tests.