### PR TITLE
chore: bump test262 version

### DIFF
--- a/packages/intl-relativetimeformat/package.json
+++ b/packages/intl-relativetimeformat/package.json
@@ -35,7 +35,8 @@
     "clean": "rimraf dist lib dist-es6",
     "compile": "tsc && api-extractor run --local && tsc -p tsconfig.cjs.json && tsc -p tsconfig.es6.json && rollup -c rollup.config.js",
     "jest": "cross-env NODE_ICU_DATA=../../node_modules/full-icu TS_NODE_PROJECT=tsconfig.cjs.json cross-env NODE_ENV=test jest",
-    "test": "npm run jest && cross-env NODE_ICU_DATA=../../node_modules/full-icu TS_NODE_PROJECT=tsconfig.cjs.json ts-node tests/runner"
+    "test262": "cross-env NODE_ICU_DATA=../../node_modules/full-icu TS_NODE_PROJECT=tsconfig.cjs.json ts-node tests/runner",
+    "test": "npm run jest && npm run test262"
   },
   "files": [
     "dist-es6",

--- a/packages/intl-relativetimeformat/src/core.ts
+++ b/packages/intl-relativetimeformat/src/core.ts
@@ -127,7 +127,7 @@ function singularRelativeTimeUnit(unit: FormattableUnit): Unit {
   return unit;
 }
 
-const NUMBERING_SYSTEM_REGEX = /[a-z0-9]{3,8}(-[a-z0-9]{3,8})*/gi;
+const NUMBERING_SYSTEM_REGEX = /^[a-z0-9]{3,8}(-[a-z0-9]{3,8})*$/i;
 
 interface RelativeTimeFormatInternal {
   numberFormat: Intl.NumberFormat;


### PR DESCRIPTION
feat(@formatjs/intl-displaynames): bump test262 submodule version to include DisplayNames test suite.
fix(@formatjs/intl-relativetimeformat): numberingSystem option now conforms to the spec.