### PR TITLE
fix(babel-plugin-react-intl): ignore default message

### DIFF
--- a/packages/babel-plugin-react-intl/src/index.ts
+++ b/packages/babel-plugin-react-intl/src/index.ts
@@ -425,9 +425,8 @@ export default declare((api: any, options: OptionsSchema) => {
           // declaring a JSX element, it must be done with standard
           // `key=value` attributes. But it's completely valid to
           // write `<FormattedMessage {...descriptor} />`, because it will be
-          // skipped here and extracted elsewhere. The descriptor will
-          // be extracted only (storeMessage) if a `defaultMessage` prop.
-          if (descriptorPath.id && descriptorPath.defaultMessage) {
+          // skipped here and extracted elsewhere.
+          if (descriptorPath.id) {
             // Evaluate the Message Descriptor values in a JSX
             // context, then store it.
             const descriptor = evaluateMessageDescriptor(

--- a/packages/babel-plugin-react-intl/test/__snapshots__/index.test.ts.snap
+++ b/packages/babel-plugin-react-intl/test/__snapshots__/index.test.ts.snap
@@ -278,6 +278,11 @@ Object {
       "description": undefined,
       "id": "TRANSLATION_KEY",
     },
+    Object {
+      "defaultMessage": undefined,
+      "description": undefined,
+      "id": "foo.bar.baz",
+    },
   ],
 }
 `;
@@ -323,6 +328,9 @@ exports[`emit asserts for:  output match: enforceDefaultMessage 3`] = `
 Array [
   Object {
     "id": "TRANSLATION_KEY",
+  },
+  Object {
+    "id": "foo.bar.baz",
   },
 ]
 `;


### PR DESCRIPTION
In the 5.0.0 release it was removed the option enforceDefaultMessage https://github.com/formatjs/formatjs/compare/babel-plugin-react-intl@4.3.0...babel-plugin-react-intl@5.0.0#diff-42d4e378cdd21405ca2ec126383c504bR432. With the current state the components like `<FormattedMessage id="global.error" />` doesn't get extracted.

