### PR TITLE
fix(intl-utils): prevent infinite recursion loop of getCanonicalRules

### DIFF
--- a/packages/intl-utils/src/get-canonical-locales.ts
+++ b/packages/intl-utils/src/get-canonical-locales.ts
@@ -8,5 +8,8 @@ export function getCanonicalLocales(locales?: string | string[]): string[] {
   if (typeof getCanonicalLocales === 'function') {
     return getCanonicalLocales(locales) as string[];
   }
-  return Intl.NumberFormat.supportedLocalesOf(locales || '');
+  // NOTE: we must NOT call `supportedLocalesOf` of a formatjs polyfill, or their implementation
+  // will even eventually call this method recursively. Here we use `Intl.DateTimeFormat` since it
+  // is not polyfilled by `@formatjs`.
+  return Intl.DateTimeFormat.supportedLocalesOf(locales || '');
 }


### PR DESCRIPTION
Fixes #543 

`Intl.getCanonicalLocales` is not available on IE11, and therefore we used to rely on
`Intl.NumberFormat.supportedLocalesOf` to polyfill this method.

However, when used together with `UnifiedNumberFormat` polyfill, this causes an infinite
recursion loop because `UnifiedNumberFormat.supportedLocalesOf` will eventually call into
`Intl.getCanonicalLocales`! This diff puts a stopgap by using `Intl.DateTimeFormat` instead,
since it is not polyfilled by formatjs.