### PR TITLE
chore: emit type declaration source map during build

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,7 @@
         "**/node_modules/*/**": true,
         "test262/**": true,
         "**/test_artifacts/**": true,
+        "**/*.map": true,
+        "**/*.d.ts.map": true,
     }
 }

--- a/packages/intl-messageformat/.npmignore
+++ b/packages/intl-messageformat/.npmignore
@@ -8,3 +8,4 @@ coverage
 *.config.js
 tsconfig.*
 .nyc_output
+*.d.ts.map

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,8 @@
         "noUnusedLocals": true,
         "noUnusedParameters": true,
         "preserveConstEnums": true,
+        "declarationMap": true,
+        "sourceMap": true,
         "types": [
             "babel__core",
             "babel__generator",


### PR DESCRIPTION
Emitting type declaration source map allows using "Go to definition" on other sub-package import to go to source code directly, instead of the emitted type declaration files.