### PR TITLE
fix(intl-messageformat): IntlMessageFormat.defaultLocale is updated to

### DIFF
--- a/packages/intl-messageformat/src/core.ts
+++ b/packages/intl-messageformat/src/core.ts
@@ -163,7 +163,15 @@ export class IntlMessageFormat {
     locale: Intl.NumberFormat.supportedLocalesOf(this.locales)[0],
   });
   getAst = () => this.ast;
-  static defaultLocale = new Intl.NumberFormat().resolvedOptions().locale;
+  private static memoizedDefaultLocale: string | null = null;
+
+  static get defaultLocale() {
+    if (!IntlMessageFormat.memoizedDefaultLocale) {
+      IntlMessageFormat.memoizedDefaultLocale = new Intl.NumberFormat().resolvedOptions().locale;
+    }
+
+    return IntlMessageFormat.memoizedDefaultLocale;
+  }
   static __parse: typeof parse | undefined = parse;
   // Default format options used as the prototype of the `formats` provided to the
   // constructor. These are used when constructing the internal Intl.NumberFormat


### PR DESCRIPTION
be a getter in order to enable lazily calculating the actual value when
it's needed first time. Also, a new private static member called 'memoizedDefaultLocale' is added to IntlMessageFormat to prevent
re-calculating the same defaultLocale each time it's referenced.

- resolve: #587