### PR TITLE
 fix(@formatjs/cli): fix `throws` option not being passed to main method

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -145,6 +145,7 @@ async function main(argv: string[]) {
         additionalComponentNames: cmdObj.additionalComponentNames,
         extractFromFormatMessageCall: cmdObj.extractFromFormatMessageCall,
         outputEmptyJson: cmdObj.outputEmptyJson,
+        throws: cmdObj.throws,
         pragma: cmdObj.pragma,
         // It is possible that the glob pattern does NOT match anything.
         // But so long as the glob pattern is provided, don't read from stdin.


### PR DESCRIPTION
This commit 75399368f6ddd591b3fbe9c3ed6d9a30bea3586f introduced the `--throws` option but it's not being passed to the extract method, so currently there is no way of getting the cli to throw on errors.
This pr just passes the option to the main method as it probably was intended by the original author.