### PR TITLE
chore: build CommonJS by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,5 @@ functional-tests/
 .rpt2_cache
 test262
 temp
-dist-es6
 polyfill-locales.js
+dist-es6

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "url": "https://github.com/formatjs/formatjs"
   },
   "scripts": {
-    "build:packages": "lerna run --parallel clean && lerna run build",
-    "build": "yarn run prettier && yarn run build:packages",
+    "build": "yarn run clean && lerna run build",
+    "clean": "lerna run --parallel clean",
     "cover:collect": "mkdir -p ./.nyc_output/ && for d in $(find packages -type d -name '.nyc_output' -maxdepth 2 -exec find '{}' -type f ';'); do (cp $d ./.nyc_output/); done; nyc report --reporter=lcov --report-dir=${COVERAGE_DIR:-artifacts/coverage}",
     "cover": "lerna run cover --since",
     "dev:test": "lerna run test --since master",
@@ -17,10 +17,10 @@
     "karma:local": "karma start karma.conf.js",
     "lint": "eslint 'packages/*/src/**/*.ts?(x)' --fix",
     "postversion": "yarn run prettier",
-    "prepublishOnly": "yarn run build",
+    "prepublishOnly": "yarn run prettier && yarn run build",
     "prettier": "prettier --write 'packages/*/{test,tests,src,scripts}/**/*.ts' 'website/**/*.js' 'packages/babel-plugin-react-intl/test/**/*.js' '**/*.md'",
     "prettier:check": "prettier --check 'packages/*/{test,tests,src,scripts}/**/*.ts' 'website/**/*.js' 'packages/babel-plugin-react-intl/test/**/*.js' '**/*.md'",
-    "test": "lerna run lint && yarn run prettier:check && lerna run --parallel test"
+    "test": "lerna run lint && yarn run prettier:check && lerna run --parallel test && jest -c tests/jest.config.js"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",

--- a/packages/babel-plugin-react-intl/package.json
+++ b/packages/babel-plugin-react-intl/package.json
@@ -25,7 +25,7 @@
     "schema-utils": "^2.6.6"
   },
   "scripts": {
-    "clean": "rimraf lib test/fixtures/**/actual.json *.tsbuildinfo",
+    "clean": "rimraf lib dist test/fixtures/**/actual.json *.tsbuildinfo",
     "test": "cross-env TS_NODE_PROJECT=./tsconfig.json cross-env NODE_ENV=test jest",
     "cover": "npm t -- --coverage",
     "build": "json2ts -i src/options.schema.json -o src/options.ts && tsc"

--- a/packages/babel-plugin-react-intl/tsconfig.json
+++ b/packages/babel-plugin-react-intl/tsconfig.json
@@ -3,11 +3,7 @@
     "compilerOptions": {
         "outDir": "dist",
         "rootDir": "src",
-        "module": "commonjs",
         "baseUrl": ".",
-        "paths": {
-            "intl-messageformat-parser": ["../intl-messageformat-parser"]
-        },
         "types": [
             "babel__core",
             "babel__generator",

--- a/packages/cli/jest.config.js
+++ b/packages/cli/jest.config.js
@@ -3,7 +3,8 @@ module.exports = {
   testEnvironment: 'node',
   globals: {
     'ts-jest': {
-      tsConfig: 'tsconfig.json'
+      // TODO: figure out editor tsconfig
+      tsConfig: 'tsconfig.jest.json'
     }
   }
 };

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,9 +36,9 @@
     "url": "git+ssh://git@github.com/formatjs/formatjs.git"
   },
   "scripts": {
-    "clean": "rimraf lib *.tsbuildinfo",
-    "build": "tsc -p tsconfig.build.json",
-    "test": "cross-env TS_NODE_PROJECT=./tsconfig.json cross-env NODE_ENV=test jest"
+    "clean": "rimraf lib dist *.tsbuildinfo",
+    "build": "tsc",
+    "test": "cross-env TS_NODE_PROJECT=./tsconfig.jest.json cross-env NODE_ENV=test jest"
   },
   "dependencies": {
     "@babel/plugin-proposal-class-properties": "^7.8.3",

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -1,9 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  // Not including tests
-  "compilerOptions": {
-    "rootDir": "src",
-    "module": "commonjs",
-  },
-  "include": ["src/**/*.ts"]
-}

--- a/packages/cli/tsconfig.jest.json
+++ b/packages/cli/tsconfig.jest.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"],
+  "exclude": ["tests/extract/integration_tests/typescript/**/*.tsx"],
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -4,8 +4,7 @@
         // Targeting node >= 8
         "target": "es2017",
         "outDir": "lib",
-        "rootDir": ".",
-        "module": "esnext",
+        "rootDir": "src",
         "esModuleInterop": true,
         "noUnusedLocals": true,
         "sourceMap": true,
@@ -30,7 +29,5 @@
             "yargs"
         ]
     },
-    // Also include tests in the default tsconfig.json for better editor integration.
-    "include": ["src/**/*.ts", "tests/**/*.ts"],
-    "exclude": ["tests/extract/integration_tests/typescript/**/*.tsx"],
+    "include": ["src/**/*.ts"],
 }

--- a/packages/eslint-plugin-formatjs/package.json
+++ b/packages/eslint-plugin-formatjs/package.json
@@ -8,7 +8,7 @@
     "src"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "tsc",
     "test": "cross-env TS_NODE_PROJECT=./tsconfig.json cross-env NODE_ENV=test jest"
   },
   "repository": {

--- a/packages/eslint-plugin-formatjs/tsconfig.build.json
+++ b/packages/eslint-plugin-formatjs/tsconfig.build.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  // Not including tests
-  "compilerOptions": {
-    "rootDir": "src",
-  },
-  "include": ["src/**/*.ts"]
-}

--- a/packages/eslint-plugin-formatjs/tsconfig.json
+++ b/packages/eslint-plugin-formatjs/tsconfig.json
@@ -3,8 +3,7 @@
     "compilerOptions": {
         "target": "es6",
         "outDir": "dist",
-        "rootDir": ".",
-        "module": "commonjs",
+        "rootDir": "src",
         "noUnusedLocals": true,
         "sourceMap": true,
         "preserveConstEnums": false,
@@ -27,5 +26,6 @@
             "stack-utils",
             "yargs"
         ]
-    }
+    },
+    "include": ["src/**/*.ts"]
 }

--- a/packages/formatjs-extract-cldr-data/package.json
+++ b/packages/formatjs-extract-cldr-data/package.json
@@ -10,7 +10,8 @@
     "src"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "tsc",
+    "clean": "rimraf dist",
     "test": "cross-env TS_NODE_PROJECT=./tsconfig.json cross-env NODE_ENV=test jest --maxWorkers=100%",
     "verify": "ts-node scripts/verify-numbers",
     "cover": "npm t -- --coverage"

--- a/packages/formatjs-extract-cldr-data/tsconfig.build.json
+++ b/packages/formatjs-extract-cldr-data/tsconfig.build.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  // Not including tests
-  "compilerOptions": {
-    "rootDir": "src",
-  },
-  "include": ["src/**/*.ts"]
-}

--- a/packages/formatjs-extract-cldr-data/tsconfig.json
+++ b/packages/formatjs-extract-cldr-data/tsconfig.json
@@ -1,13 +1,8 @@
 {
     "extends": "../../tsconfig.json",
     "compilerOptions": {
-        "module": "commonjs",
         "outDir": "dist",
         "rootDir": "src",
-        "baseUrl": ".",
-        "paths": {
-            "intl-messageformat-parser": ["../intl-messageformat-parser"]
-        },
         "types": [
             "babel__core",
             "babel__generator",
@@ -28,5 +23,6 @@
             "stack-utils",
             "yargs"
         ]
-    }
+    },
+    "include": ["src"]
 }

--- a/packages/intl-displaynames/jest.config.js
+++ b/packages/intl-displaynames/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   testEnvironment: 'node',
   globals: {
     'ts-jest': {
-      tsConfig: 'tsconfig.cjs.json'
+      tsConfig: 'tsconfig.json'
     }
   }
 };

--- a/packages/intl-displaynames/package.json
+++ b/packages/intl-displaynames/package.json
@@ -14,9 +14,9 @@
   "author": "Linjie Ding <pyrocat101@users.noreply.github.com>",
   "homepage": "https://github.com/formatjs/formatjs",
   "license": "MIT",
-  "jsnext": "dist-es6/index.js",
   "main": "dist/index.js",
   "module": "lib/index.js",
+  "module:es6": "dist-es6/index.js",
   "types": "lib/index.d.js",
   "files": [
     "dist",
@@ -36,14 +36,14 @@
     "formatjs-extract-cldr-data": "^10.1.5"
   },
   "scripts": {
-    "cldr": "ts-node --project tsconfig.cjs.json scripts/cldr",
+    "cldr": "ts-node scripts/cldr",
     "build": "yarn run cldr && yarn run compile && yarn run rollup",
     "clean": "rimraf dist dist-es6 lib *.tsbuildinfo",
-    "jest": "cross-env NODE_ICU_DATA=../../node_modules/full-icu TS_NODE_PROJECT=tsconfig.cjs.json cross-env NODE_ENV=test jest",
-    "test262": "cross-env NODE_ICU_DATA=../../node_modules/full-icu TS_NODE_PROJECT=tsconfig.cjs.json ts-node tests/runner",
+    "jest": "cross-env NODE_ICU_DATA=../../node_modules/full-icu cross-env NODE_ENV=test jest",
+    "test262": "cross-env NODE_ICU_DATA=../../node_modules/full-icu ts-node tests/runner",
     "test": "yarn run jest && yarn run test262",
     "rollup": "rollup -c rollup.config.js",
-    "compile": "tsc && tsc -p tsconfig.cjs.json && tsc -p tsconfig.es6.json && api-extractor run --local"
+    "compile": "tsc && tsc -p tsconfig.esm.json && tsc -p tsconfig.es6.json && api-extractor run --local"
   },
   "bugs": {
     "url": "https://github.com/formatjs/formatjs/issues"

--- a/packages/intl-displaynames/rollup.config.js
+++ b/packages/intl-displaynames/rollup.config.js
@@ -63,7 +63,7 @@ export default [
       name: 'IntlDisplayNames'
     },
     plugins: [resolve({
-      mainFields: ['jsnext', 'module', 'main']
+      mainFields: ['module:es6', 'module', 'main']
     }), commonjsConfig, jsonConfig]
   },
 ];

--- a/packages/intl-displaynames/tsconfig.es6.json
+++ b/packages/intl-displaynames/tsconfig.es6.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
       "target": "es6",
+      "module": "esnext",
       "outDir": "dist-es6",
   }
 }

--- a/packages/intl-displaynames/tsconfig.esm.json
+++ b/packages/intl-displaynames/tsconfig.esm.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-      "outDir": "dist",
-      "module": "commonjs"
+      "outDir": "lib",
+      "module": "esnext"
   },
 }

--- a/packages/intl-displaynames/tsconfig.json
+++ b/packages/intl-displaynames/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
       "lib": ["dom", "es5", "esnext.intl", "es2017.intl", "es2018.intl"],
-      "outDir": "lib",
+      "outDir": "dist",
       "rootDir": "src",
       "allowSyntheticDefaultImports": true,
       "noFallthroughCasesInSwitch": true,

--- a/packages/intl-format-cache/package.json
+++ b/packages/intl-format-cache/package.json
@@ -11,10 +11,10 @@
     "src"
   ],
   "scripts": {
-    "clean": "rimraf dist lib *.tsbuildinfo",
-    "benchmark": "ts-node --project tsconfig.cjs.json tests/benchmark",
-    "build": "tsc && tsc -p tsconfig.cjs.json && rollup -c rollup.config.js",
-    "test": "cross-env TS_NODE_PROJECT=../../tsconfig.cjs.json mocha --opts ../../mocha.opts tests/index.ts"
+    "clean": "rimraf dist lib tests/browser.js tests/browser.js.map *.tsbuildinfo",
+    "benchmark": "ts-node tests/benchmark",
+    "build": "tsc && tsc -p tsconfig.esm.json && rollup -c rollup.config.js",
+    "test": "mocha --opts ../../mocha.opts tests/index.ts"
   },
   "devDependencies": {
     "@formatjs/intl-pluralrules": "^1.5.6",

--- a/packages/intl-format-cache/tsconfig.cjs.json
+++ b/packages/intl-format-cache/tsconfig.cjs.json
@@ -1,8 +1,0 @@
-{
-    "extends": "./tsconfig.json",
-    "compilerOptions": {
-        "outDir": "dist",
-        "module": "commonjs"
-    },
-    "include": ["src/*.ts"]
-}

--- a/packages/intl-format-cache/tsconfig.esm.json
+++ b/packages/intl-format-cache/tsconfig.esm.json
@@ -1,6 +1,7 @@
 {
     "extends": "./tsconfig.json",
     "compilerOptions": {
-        "module": "commonjs"
-    }
+        "outDir": "lib",
+        "module": "esnext"
+    },
 }

--- a/packages/intl-format-cache/tsconfig.json
+++ b/packages/intl-format-cache/tsconfig.json
@@ -1,13 +1,8 @@
 {
     "extends": "../../tsconfig.json",
     "compilerOptions": {
-        "outDir": "lib",
+        "outDir": "dist",
         "rootDir": "src",
-        "baseUrl": ".",
-        "paths": {
-            "@formatjs/intl-relativetimeformat": ["../intl-relativetimeformat"],
-            "intl-messageformat": ["../intl-messageformat"]
-        }
     },
-    "include": ["src/*.ts"]
+    "include": ["src"]
 }

--- a/packages/intl-listformat/.gitignore
+++ b/packages/intl-listformat/.gitignore
@@ -5,4 +5,3 @@ tests/browser.*
 src/locales.ts
 src/en.ts
 tests/polyfill-all.js
-dist-es6/

--- a/packages/intl-listformat/jest.config.js
+++ b/packages/intl-listformat/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   testEnvironment: 'node',
   globals: {
     'ts-jest': {
-      tsConfig: 'tsconfig.cjs.json'
+      tsConfig: 'tsconfig.json'
     }
   }
 };

--- a/packages/intl-listformat/package.json
+++ b/packages/intl-listformat/package.json
@@ -36,11 +36,11 @@
   ],
   "scripts": {
     "build": "yarn run cldr && yarn run compile",
-    "cldr": "ts-node --project tsconfig.cjs.json scripts/cldr",
-    "clean": "rimraf dist lib dist-es6 *.tsbuildinfo",
-    "compile": "tsc && api-extractor run --local && tsc -p tsconfig.cjs.json && tsc -p tsconfig.es6.json && rollup -c rollup.config.js",
-    "jest": "cross-env NODE_ICU_DATA=../../node_modules/full-icu TS_NODE_PROJECT=tsconfig.cjs.json cross-env NODE_ENV=test jest",
-    "test": "yarn run jest && cross-env NODE_ICU_DATA=../../node_modules/full-icu TS_NODE_PROJECT=tsconfig.cjs.json ts-node tests/runner"
+    "cldr": "ts-node scripts/cldr",
+    "clean": "rimraf dist lib dist-es6 dist-es6 *.tsbuildinfo",
+    "compile": "tsc && tsc -p tsconfig.esm.json && tsc -p tsconfig.es6.json && api-extractor run --local && rollup -c rollup.config.js",
+    "jest": "cross-env NODE_ICU_DATA=../../node_modules/full-icu NODE_ENV=test jest",
+    "test": "yarn run jest && cross-env NODE_ICU_DATA=../../node_modules/full-icu ts-node tests/runner"
   },
   "homepage": "https://github.com/formatjs/formatjs",
   "license": "MIT",

--- a/packages/intl-listformat/tsconfig.cjs.json
+++ b/packages/intl-listformat/tsconfig.cjs.json
@@ -1,8 +1,0 @@
-{
-    "extends": "./tsconfig.json",
-    "compilerOptions": {
-        "outDir": "dist",
-        "module": "commonjs"
-    },
-    "include": ["src/*.ts"]
-}

--- a/packages/intl-listformat/tsconfig.es6.json
+++ b/packages/intl-listformat/tsconfig.es6.json
@@ -2,6 +2,7 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "target": "es6",
+        "module": "esnext",
         "outDir": "dist-es6"
     }
 }

--- a/packages/intl-listformat/tsconfig.esm.json
+++ b/packages/intl-listformat/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+        "module": "esnext"
+    }
+}

--- a/packages/intl-listformat/tsconfig.json
+++ b/packages/intl-listformat/tsconfig.json
@@ -2,9 +2,8 @@
     "extends": "../../tsconfig.json",
     "compilerOptions": {
         "lib": ["dom", "es5", "esnext.intl", "es2017.intl", "es2018.intl"],
-        "outDir": "lib",
+        "outDir": "dist",
         "rootDir": "src",
-        "baseUrl": ".",
         "types": [
             "babel__core",
             "babel__generator",
@@ -25,9 +24,6 @@
             "stack-utils",
             "yargs"
         ],
-        "paths": {
-            "@formatjs/intl-utils": ["../intl-utils"]
-        }
     },
-    "include": ["src/*.ts"]
+    "include": ["src"]
 }

--- a/packages/intl-locales-supported/package.json
+++ b/packages/intl-locales-supported/package.json
@@ -30,8 +30,8 @@
   "homepage": "https://github.com/formatjs/formatjs",
   "scripts": {
     "clean": "rimraf dist lib *.tsbuildinfo",
-    "build": "tsc && tsc -p tsconfig.cjs.json",
-    "test": "cross-env NODE_ICU_DATA=../../node_modules/full-icu TS_NODE_PROJECT=../../tsconfig.cjs.json mocha --opts ../../mocha.opts tests/index.ts"
+    "build": "tsc && tsc -p tsconfig.esm.json",
+    "test": "cross-env NODE_ICU_DATA=../../node_modules/full-icu mocha --opts ../../mocha.opts tests/index.ts"
   },
   "gitHead": "a7842673d8ad205171ad7c8cb8bb2f318b427c0c"
 }

--- a/packages/intl-locales-supported/tsconfig.cjs.json
+++ b/packages/intl-locales-supported/tsconfig.cjs.json
@@ -1,8 +1,0 @@
-{
-    "extends": "./tsconfig.json",
-    "compilerOptions": {
-        "outDir": "dist",
-        "module": "commonjs"
-    },
-    "include": ["src/*.ts"]
-}

--- a/packages/intl-locales-supported/tsconfig.esm.json
+++ b/packages/intl-locales-supported/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+        "module": "esnext"
+    },
+}

--- a/packages/intl-locales-supported/tsconfig.json
+++ b/packages/intl-locales-supported/tsconfig.json
@@ -1,8 +1,8 @@
 {
     "extends": "../../tsconfig.json",
     "compilerOptions": {
-        "outDir": "lib",
+        "outDir": "dist",
         "rootDir": "src"
     },
-    "include": ["src/*.ts"]
+    "include": ["src"],
 }

--- a/packages/intl-messageformat-parser/jest.config.js
+++ b/packages/intl-messageformat-parser/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   testEnvironment: 'node',
   globals: {
     'ts-jest': {
-      tsConfig: 'tsconfig.cjs.json'
+      tsConfig: 'tsconfig.json'
     }
   }
 };

--- a/packages/intl-messageformat-parser/package.json
+++ b/packages/intl-messageformat-parser/package.json
@@ -12,9 +12,9 @@
   ],
   "scripts": {
     "clean": "rimraf dist lib *.tsbuildinfo",
-    "build": "node build.js && tsc && api-extractor run --local && tsc -p tsconfig.cjs.json && rollup -c rollup.config.js",
+    "build": "node build.js && tsc && tsc -p tsconfig.esm.json && api-extractor run --local && rollup -c rollup.config.js",
     "benchmark": "node ./test/benchmark.js",
-    "test": "cross-env TS_NODE_PROJECT=./tsconfig.cjs.json cross-env NODE_ENV=test jest"
+    "test": "cross-env NODE_ENV=test jest"
   },
   "contributors": [
     "Eric Ferraiuolo <eferraiuolo@gmail.com>",

--- a/packages/intl-messageformat-parser/tsconfig.cjs.json
+++ b/packages/intl-messageformat-parser/tsconfig.cjs.json
@@ -1,8 +1,0 @@
-{
-    "extends": "./tsconfig.json",
-    "compilerOptions": {
-        "outDir": "dist",
-        "module": "commonjs",
-    },
-    "include": ["src/*.ts"]
-}

--- a/packages/intl-messageformat-parser/tsconfig.esm.json
+++ b/packages/intl-messageformat-parser/tsconfig.esm.json
@@ -1,8 +1,7 @@
 {
     "extends": "./tsconfig.json",
     "compilerOptions": {
-        "target": "es6",
+        "outDir": "lib",
         "module": "esnext",
-        "outDir": "dist-es6",
     },
 }

--- a/packages/intl-messageformat-parser/tsconfig.json
+++ b/packages/intl-messageformat-parser/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "extends": "../../tsconfig.json",
     "compilerOptions": {
-        "outDir": "lib",
+        "outDir": "dist",
         "rootDir": "src",
         "baseUrl": ".",
         "noImplicitAny": false,
@@ -24,5 +24,5 @@
             "yargs"
         ]
     },
-    "include": ["src/*.ts"]
+    "include": ["src"]
 }

--- a/packages/intl-messageformat/package.json
+++ b/packages/intl-messageformat/package.json
@@ -44,14 +44,14 @@
   },
   "sideEffects": false,
   "scripts": {
-    "benchmark": "ts-node --project ./tsconfig.cjs.json tests/benchmark",
+    "benchmark": "ts-node tests/benchmark",
     "build": "yarn run tsc && yarn run rollup",
     "clean": "rimraf dist lib *.tsbuildinfo",
     "karma:ci": "karma start karma.conf-ci.js",
     "karma:local": "karma start karma.conf.js",
     "rollup": "rollup -c rollup.config.js",
-    "test": "cross-env TZ=UTC NODE_ICU_DATA=../../node_modules/full-icu TS_NODE_PROJECT=tsconfig.cjs.json mocha --opts ../../mocha.opts -r tests/setup.js tests/index.ts",
-    "tsc": "tsc -p src/tsconfig.json && tsc -p src/tsconfig.cjs.json && api-extractor run --local"
+    "test": "cross-env TZ=UTC NODE_ICU_DATA=../../node_modules/full-icu mocha --opts ../../mocha.opts -r tests/setup.js tests/index.ts",
+    "tsc": "tsc -p tsconfig.json && tsc -p tsconfig.esm.json && api-extractor run --local"
   },
   "homepage": "https://github.com/formatjs/formatjs",
   "directories": {

--- a/packages/intl-messageformat/src/tsconfig.json
+++ b/packages/intl-messageformat/src/tsconfig.json
@@ -1,9 +1,0 @@
-{
-    "extends": "../tsconfig.json",
-    "compilerOptions": {
-        "outDir": "../lib",
-        "paths": {
-            "intl-format-cache": ["../intl-format-cache"]
-        }
-    }
-}

--- a/packages/intl-messageformat/tsconfig.esm.json
+++ b/packages/intl-messageformat/tsconfig.esm.json
@@ -1,7 +1,7 @@
 {
     "extends": "./tsconfig.json",
     "compilerOptions": {
-        "outDir": "../dist",
-        "module": "commonjs"
+        "module": "esnext",
+        "outDir": "lib"
     }
 }

--- a/packages/intl-messageformat/tsconfig.json
+++ b/packages/intl-messageformat/tsconfig.json
@@ -1,9 +1,8 @@
 {
     "extends": "../../tsconfig.json",
     "compilerOptions": {
-        "baseUrl": ".",
-        "paths": {
-            "intl-format-cache": ["../intl-format-cache"]
-        }
-    }
+        "outDir": "dist",
+        "rootDir": "src"
+    },
+    "include": ["src"]
 }

--- a/packages/intl-pluralrules/.gitignore
+++ b/packages/intl-pluralrules/.gitignore
@@ -2,4 +2,3 @@ src/en.ts
 src/locales.js
 src/units-constants.ts
 polyfill-locales.js
-dist-es6

--- a/packages/intl-pluralrules/jest.config.js
+++ b/packages/intl-pluralrules/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   testEnvironment: 'node',
   globals: {
     'ts-jest': {
-      tsConfig: 'tsconfig.cjs.json'
+      tsConfig: 'tsconfig.json'
     }
   }
 };

--- a/packages/intl-pluralrules/package.json
+++ b/packages/intl-pluralrules/package.json
@@ -35,11 +35,11 @@
   },
   "scripts": {
     "build": "yarn run cldr && yarn run compile",
-    "cldr": "ts-node --project tsconfig.cjs.json scripts/cldr",
+    "cldr": "ts-node scripts/cldr",
     "clean": "rimraf dist lib dist-es6 polyfill-locales.js *.tsbuildinfo",
-    "compile": "tsc && api-extractor run --local && tsc -p tsconfig.cjs.json && tsc -p tsconfig.es6.json && rollup -c rollup.config.js",
-    "jest": "cross-env NODE_ICU_DATA=../../node_modules/full-icu TS_NODE_PROJECT=tsconfig.cjs.json cross-env NODE_ENV=test jest",
-    "test262": "cross-env NODE_ICU_DATA=../../node_modules/full-icu TS_NODE_PROJECT=tsconfig.cjs.json ts-node tests/runner",
+    "compile": "tsc && tsc -p tsconfig.esm.json && api-extractor run --local && tsc -p tsconfig.es6.json && rollup -c rollup.config.js",
+    "jest": "cross-env NODE_ICU_DATA=../../node_modules/full-icu cross-env NODE_ENV=test jest",
+    "test262": "cross-env NODE_ICU_DATA=../../node_modules/full-icu ts-node tests/runner",
     "test": "yarn run jest && yarn run test262"
   },
   "bugs": {

--- a/packages/intl-pluralrules/tsconfig.cjs.json
+++ b/packages/intl-pluralrules/tsconfig.cjs.json
@@ -1,7 +1,0 @@
-{
-    "extends": "./tsconfig.json",
-    "compilerOptions": {
-        "outDir": "dist",
-        "module": "commonjs"
-    }
-}

--- a/packages/intl-pluralrules/tsconfig.es6.json
+++ b/packages/intl-pluralrules/tsconfig.es6.json
@@ -2,6 +2,7 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "target": "es6",
+        "module": "esnext",
         "outDir": "dist-es6",
     }
 }

--- a/packages/intl-pluralrules/tsconfig.esm.json
+++ b/packages/intl-pluralrules/tsconfig.esm.json
@@ -1,8 +1,7 @@
 {
     "extends": "./tsconfig.json",
     "compilerOptions": {
-        "target": "es6",
+        "outDir": "lib",
         "module": "esnext",
-        "outDir": "dist-es6",
-    },
+    }
 }

--- a/packages/intl-pluralrules/tsconfig.json
+++ b/packages/intl-pluralrules/tsconfig.json
@@ -2,7 +2,7 @@
     "extends": "../../tsconfig.json",
     "compilerOptions": {
         "lib": ["dom", "es5", "esnext.intl", "es2017.intl", "es2018.intl"],
-        "outDir": "lib",
+        "outDir": "dist",
         "rootDir": "src",
         "types": [
             "babel__core",
@@ -25,5 +25,5 @@
             "yargs"
         ]
     },
-    "include": ["src/*.ts"]
+    "include": ["src"]
 }

--- a/packages/intl-relativetimeformat/jest.config.js
+++ b/packages/intl-relativetimeformat/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   testEnvironment: 'node',
   globals: {
     'ts-jest': {
-      tsConfig: 'tsconfig.cjs.json'
+      tsConfig: 'tsconfig.json'
     }
   }
 };

--- a/packages/intl-relativetimeformat/package.json
+++ b/packages/intl-relativetimeformat/package.json
@@ -31,11 +31,11 @@
   "types": "lib/intl-relativetimeformat.d.ts",
   "scripts": {
     "build": "yarn run cldr && yarn run compile",
-    "cldr": "ts-node --project tsconfig.cjs.json scripts/cldr",
+    "cldr": "ts-node scripts/cldr",
     "clean": "rimraf dist lib dist-es6 *.tsbuildinfo",
-    "compile": "tsc && api-extractor run --local && tsc -p tsconfig.cjs.json && tsc -p tsconfig.es6.json && rollup -c rollup.config.js",
-    "jest": "cross-env NODE_ICU_DATA=../../node_modules/full-icu TS_NODE_PROJECT=tsconfig.cjs.json cross-env NODE_ENV=test jest",
-    "test262": "cross-env NODE_ICU_DATA=../../node_modules/full-icu TS_NODE_PROJECT=tsconfig.cjs.json ts-node tests/runner",
+    "compile": "tsc && tsc -p tsconfig.esm.json && api-extractor run --local && tsc -p tsconfig.es6.json && rollup -c rollup.config.js",
+    "jest": "cross-env NODE_ICU_DATA=../../node_modules/full-icu cross-env NODE_ENV=test jest",
+    "test262": "cross-env NODE_ICU_DATA=../../node_modules/full-icu ts-node tests/runner",
     "test": "yarn run jest && yarn run test262"
   },
   "files": [

--- a/packages/intl-relativetimeformat/tsconfig.cjs.json
+++ b/packages/intl-relativetimeformat/tsconfig.cjs.json
@@ -1,8 +1,0 @@
-{
-    "extends": "./tsconfig.json",
-    "compilerOptions": {
-        "outDir": "dist",
-        "module": "commonjs"
-    },
-    "include": ["src/*.ts"]
-}

--- a/packages/intl-relativetimeformat/tsconfig.es6.json
+++ b/packages/intl-relativetimeformat/tsconfig.es6.json
@@ -2,6 +2,7 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "target": "es6",
+        "module": "esnext",
         "outDir": "dist-es6"
     }
 }

--- a/packages/intl-relativetimeformat/tsconfig.esm.json
+++ b/packages/intl-relativetimeformat/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+        "module": "esnext"
+    },
+}

--- a/packages/intl-relativetimeformat/tsconfig.json
+++ b/packages/intl-relativetimeformat/tsconfig.json
@@ -2,7 +2,7 @@
     "extends": "../../tsconfig.json",
     "compilerOptions": {
         "lib": ["dom", "es5", "esnext.intl", "es2017.intl", "es2018.intl"],
-        "outDir": "lib",
+        "outDir": "dist",
         "rootDir": "src",
         "downlevelIteration": true,
         "types": [
@@ -26,5 +26,5 @@
             "yargs"
         ]
     },
-    "include": ["src/*.ts"]
+    "include": ["src"]
 }

--- a/packages/intl-unified-numberformat/jest.config.js
+++ b/packages/intl-unified-numberformat/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   testEnvironment: 'node',
   globals: {
     'ts-jest': {
-      tsConfig: 'tsconfig.cjs.json'
+      tsConfig: 'tsconfig.json'
     }
   }
 };

--- a/packages/intl-unified-numberformat/package.json
+++ b/packages/intl-unified-numberformat/package.json
@@ -33,15 +33,15 @@
     "@formatjs/intl-utils": "^2.2.3"
   },
   "scripts": {
-    "benchmark": "ts-node --project ./tsconfig.cjs.json tests/benchmark",
+    "benchmark": "ts-node tests/benchmark",
     "build": "yarn run cldr && yarn run compile && yarn run rollup ",
-    "cldr": "NODE_OPTIONS=--max-old-space-size=8192 ts-node --project tsconfig.cjs.json scripts/cldr",
+    "cldr": "NODE_OPTIONS=--max-old-space-size=8192 ts-node scripts/cldr",
     "clean": "rimraf dist dist-es6 lib src/locales.ts *.tsbuildinfo",
-    "compile": "NODE_OPTIONS=--max-old-space-size=8192 tsc && tsc -p tsconfig.cjs.json && tsc -p tsconfig.es6.json && api-extractor run --local",
-    "jest": "cross-env NODE_ICU_DATA=../../node_modules/full-icu TS_NODE_PROJECT=tsconfig.cjs.json cross-env NODE_ENV=test jest",
+    "compile": "NODE_OPTIONS=--max-old-space-size=8192 tsc && tsc -p tsconfig.esm.json && tsc -p tsconfig.es6.json && api-extractor run --local",
+    "jest": "cross-env NODE_ICU_DATA=../../node_modules/full-icu cross-env NODE_ENV=test jest",
     "rollup": "NODE_OPTIONS=--max-old-space-size=8192 rollup -c rollup.config.js",
     "test": "yarn run jest",
-    "test262": "cross-env NODE_ICU_DATA=../../node_modules/full-icu TS_NODE_PROJECT=tsconfig.cjs.json ts-node tests/runner"
+    "test262": "cross-env NODE_ICU_DATA=../../node_modules/full-icu ts-node tests/runner"
   },
   "bugs": {
     "url": "https://github.com/formatjs/formatjs/issues"

--- a/packages/intl-unified-numberformat/rollup.config.js
+++ b/packages/intl-unified-numberformat/rollup.config.js
@@ -62,7 +62,7 @@ export default [
     plugins: [resolve({
       // For test262, we want to use ES6 distribution to avoid a myriad of errors
       // that could be introduced by transpiled code.
-      mainFields: ['jsnext']
+      mainFields: ['module:es6']
     }), commonjsConfig, jsonConfig]
   },
 ];

--- a/packages/intl-unified-numberformat/tsconfig.cjs.json
+++ b/packages/intl-unified-numberformat/tsconfig.cjs.json
@@ -1,7 +1,0 @@
-{
-    "extends": "./tsconfig.json",
-    "compilerOptions": {
-        "outDir": "dist",
-        "module": "commonjs"
-    }
-}

--- a/packages/intl-unified-numberformat/tsconfig.es6.json
+++ b/packages/intl-unified-numberformat/tsconfig.es6.json
@@ -2,6 +2,7 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "target": "es6",
+        "module": "esnext",
         "outDir": "dist-es6",
     }
 }

--- a/packages/intl-unified-numberformat/tsconfig.esm.json
+++ b/packages/intl-unified-numberformat/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+        "module": "esnext"
+    }
+}

--- a/packages/intl-unified-numberformat/tsconfig.json
+++ b/packages/intl-unified-numberformat/tsconfig.json
@@ -2,7 +2,7 @@
     "extends": "../../tsconfig.json",
     "compilerOptions": {
         "lib": ["dom", "es5", "esnext.intl", "es2017.intl", "es2018.intl"],
-        "outDir": "lib",
+        "outDir": "dist",
         "rootDir": "src",
         "allowSyntheticDefaultImports": true,
         "noFallthroughCasesInSwitch": true,
@@ -27,5 +27,5 @@
             "yargs"
         ]
     },
-    "include": ["src/*.ts"],
+    "include": ["src"]
 }

--- a/packages/intl-utils/package.json
+++ b/packages/intl-utils/package.json
@@ -21,7 +21,7 @@
   "sideEffects": false,
   "main": "dist/index.js",
   "module": "lib/index.js",
-  "jsnext": "dist-es6/index.js",
+  "module:es6": "dist-es6/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -29,10 +29,10 @@
     "src"
   ],
   "scripts": {
-    "clean": "rimraf dist lib *.tsbuildinfo",
-    "cldr": "ts-node --project tsconfig.cjs.json scripts/cldr",
-    "build": "yarn run cldr && tsc && api-extractor run --local && tsc -p tsconfig.es6.json && tsc -p tsconfig.cjs.json",
-    "test": "cross-env TS_NODE_PROJECT=tsconfig.cjs.json mocha --opts ../../mocha.opts tests/*"
+    "clean": "rimraf dist dist-es6 lib *.tsbuildinfo",
+    "cldr": "ts-node scripts/cldr",
+    "build": "yarn run cldr && tsc && tsc -p tsconfig.esm.json && tsc -p tsconfig.es6.json && api-extractor run --local",
+    "test": "mocha --opts ../../mocha.opts tests/*"
   },
   "homepage": "https://github.com/formatjs/formatjs",
   "license": "MIT",

--- a/packages/intl-utils/tsconfig.cjs.json
+++ b/packages/intl-utils/tsconfig.cjs.json
@@ -1,8 +1,0 @@
-{
-    "extends": "./tsconfig.json",
-    "compilerOptions": {
-        "outDir": "dist",
-        "module": "commonjs",
-    },
-    "include": ["src/*.ts"]
-}

--- a/packages/intl-utils/tsconfig.esm.json
+++ b/packages/intl-utils/tsconfig.esm.json
@@ -1,8 +1,7 @@
 {
     "extends": "./tsconfig.json",
     "compilerOptions": {
-        "target": "es6",
+        "outDir": "lib",
         "module": "esnext",
-        "outDir": "dist-es6",
     },
 }

--- a/packages/intl-utils/tsconfig.json
+++ b/packages/intl-utils/tsconfig.json
@@ -1,13 +1,9 @@
 {
     "extends": "../../tsconfig.json",
     "compilerOptions": {
-        "outDir": "lib",
+        "outDir": "dist",
         "rootDir": "src",
-        "baseUrl": ".",
-        "paths": {
-            "@formatjs/intl-relativetimeformat": ["../intl-relativetimeformat"]
-        },
         "allowSyntheticDefaultImports": true
     },
-    "include": ["src/*.ts"]
+    "include": ["src"]
 }

--- a/packages/macro/package.json
+++ b/packages/macro/package.json
@@ -30,7 +30,7 @@
   },
   "scripts": {
     "clean": "rimraf lib *.tsbuildinfo",
-    "build": "tsc -p tsconfig.build.json"
+    "build": "tsc"
   },
   "files": [
     "dist",

--- a/packages/macro/tsconfig.build.json
+++ b/packages/macro/tsconfig.build.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  // Not including tests
-  "compilerOptions": {
-    "rootDir": "src",
-  },
-  "include": ["src/**/*.ts"]
-}

--- a/packages/macro/tsconfig.json
+++ b/packages/macro/tsconfig.json
@@ -1,10 +1,9 @@
 {
     "extends": "../../tsconfig.json",
     "compilerOptions": {
-        "target": "esnext",
+        "target": "es2019",
         "outDir": "dist",
-        "rootDir": ".",
-        "module": "commonjs",
+        "rootDir": "src",
         "noUnusedLocals": true,
         "sourceMap": true,
         "types": [

--- a/packages/ts-transformer/package.json
+++ b/packages/ts-transformer/package.json
@@ -4,8 +4,8 @@
   "description": "TS Compiler transformer for formatjs",
   "main": "dist/index.js",
   "scripts": {
-    "test": "rm -rf test/fixture/*.js && cross-env TS_NODE_PROJECT=./tsconfig.json cross-env NODE_ENV=test jest --maxWorkers=100%",
-    "build": "tsc -p tsconfig.build.json"
+    "test": "rm -rf test/fixture/*.js && cross-env NODE_ENV=test jest --maxWorkers=100%",
+    "build": "tsc"
   },
   "repository": {
     "type": "git",

--- a/packages/ts-transformer/tsconfig.build.json
+++ b/packages/ts-transformer/tsconfig.build.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  // Not including tests
-  "compilerOptions": {
-    "rootDir": "src",
-  },
-  "include": ["src/**/*.ts"]
-}

--- a/packages/ts-transformer/tsconfig.json
+++ b/packages/ts-transformer/tsconfig.json
@@ -3,8 +3,7 @@
     "compilerOptions": {
         "target": "es6",
         "outDir": "dist",
-        "rootDir": ".",
-        "module": "commonjs",
+        "rootDir": "src",
         "noUnusedLocals": true,
         "sourceMap": true,
         "types": [
@@ -28,6 +27,7 @@
             "resolve",
             "stack-utils",
             "yargs"
-        ]
-    }
+        ],
+    },
+    "include": ["src"]
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,34 +2,42 @@ import resolve from 'rollup-plugin-node-resolve';
 import typescript from 'rollup-plugin-typescript2';
 import commonjs from 'rollup-plugin-commonjs';
 import replace from 'rollup-plugin-replace';
+
 const resolveConfig = resolve({
   customResolveOptions: {
     '@formatjs/intl-pluralrules': './packages/intl-pluralrules',
     '@formatjs/intl-relativetimeformat': './packages/intl-relativetimeformat',
     '@formatjs/intl-utils': './packages/intl-utils',
     'intl-messageformat': './packages/intl-messageformat',
-  }
-})
+  },
+});
+
 export default [
   {
     input: './tests/index.ts',
     output: {
       sourcemap: true,
       file: 'tests/browser.js',
-      format: 'umd'
+      format: 'umd',
     },
     plugins: [
       replace({
         'process.env.NODE_ENV': JSON.stringify('test'),
-        'process.version': JSON.stringify('')
+        'process.version': JSON.stringify(''),
       }),
-      resolveConfig, 
+      resolveConfig,
       typescript({
-      tsconfigDefaults: {
-        compilerOptions: {
-          declaration: false
-        }
-      }
-    }) , commonjs()]
-  }
+        // This is meant to be import and used in sub-packages, where a tsconfig.esm.json
+        // is assumed to exist.
+        tsconfig: './tsconfig.esm.json',
+        tsconfigDefaults: {
+          compilerOptions: {
+            declaration: false,
+            declarationMap: false,
+          },
+        },
+      }),
+      commonjs(),
+    ],
+  },
 ];

--- a/tests/ensure_output_structure.test.ts
+++ b/tests/ensure_output_structure.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Tests to ensure that `dist` or `lib` mirrors the source file tree.
+ */
+
+import path from 'path';
+import glob from 'glob';
+import {readJsonSync, readdir, existsSync, readdirSync} from 'fs-extra';
+
+const PACKAGES_DIR = path.resolve(__dirname, '../packages');
+
+function checkBuildFolderStructure(
+  buildOutputFolder: string,
+  sourceFilesRelativeToSrcFolder: readonly string[]
+) {
+  expect(readdirSync(buildOutputFolder)).not.toContain('src');
+  expect(readdirSync(buildOutputFolder)).not.toContain('tests');
+
+  for (const file of sourceFilesRelativeToSrcFolder) {
+    const builtFile = file.replace(/\.tsx?$/, '.js');
+    expect(existsSync(path.resolve(buildOutputFolder, builtFile))).toBe(true);
+  }
+}
+
+for (const packageJsonPath of glob.sync(`${PACKAGES_DIR}/*/package.json`)) {
+  const packageJson = readJsonSync(packageJsonPath);
+  const packagePath = path.dirname(packageJsonPath);
+
+  test(`${packageJson.name}: the build output matches the source file tree`, () => {
+    const mainEntry: string = packageJson.main;
+    const moduleEntry: string | undefined = packageJson.module;
+
+    const sourceFiles = glob.sync('**/*.ts{,x}', {
+      cwd: path.resolve(packagePath, 'src'),
+    });
+
+    // Assumes the main field value is like `lib/index.js` or `dist/index.js`.
+    const mainEntryPath = path.resolve(packagePath, mainEntry);
+    const distFolder = path.dirname(mainEntryPath);
+
+    checkBuildFolderStructure(distFolder, sourceFiles);
+
+    if (moduleEntry) {
+      const moduleEntryPath = path.resolve(packagePath, moduleEntry);
+      const moduleDistFolder = path.dirname(moduleEntryPath);
+      checkBuildFolderStructure(moduleDistFolder, sourceFiles);
+    }
+  });
+}

--- a/tests/jest.config.js
+++ b/tests/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2019",
+    "strict": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "types": ["jest"],
+  }
+}

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,6 +1,0 @@
-{
-    "extends": "./tsconfig.json",
-    "compilerOptions": {
-        "module": "commonjs"
-    }
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "module": "es6",
+        "module": "commonjs",
         "moduleResolution": "node",
         "target": "es5",
         "lib": ["es6", "dom", "es2018.intl"],


### PR DESCRIPTION
This PR changes tsconfig.json in all packages to build CommonJS by default, and optionally use tsconfig.esm.json to output ES module build results.

This is the preparation work for introducing composite project and incremental build to FormatJS repo. With composite project, it is possible to build all packages incrementally with tsc watch mode during the development, instead of going into individual subpackage to run `npm run build`.