### PR TITLE
chore: use TypeScript project references

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   },
   "scripts": {
     "build": "yarn run clean && lerna run build",
-    "clean": "lerna run --parallel clean",
+    "build:cjs": "tsc -b packages/*",
+    "dev:cjs": "tsc -b packages/* --watch",
+    "clean": "rimraf packages/*/*.tsbuildinfo && lerna run --parallel clean",
     "cover:collect": "mkdir -p ./.nyc_output/ && for d in $(find packages -type d -name '.nyc_output' -maxdepth 2 -exec find '{}' -type f ';'); do (cp $d ./.nyc_output/); done; nyc report --reporter=lcov --report-dir=${COVERAGE_DIR:-artifacts/coverage}",
     "cover": "lerna run cover --since",
     "dev:test": "lerna run test --since master",

--- a/packages/babel-plugin-react-intl/tsconfig.json
+++ b/packages/babel-plugin-react-intl/tsconfig.json
@@ -27,5 +27,6 @@
         "sourceMap": true,
         "esModuleInterop": true
     },
-    "include": ["src/*.ts"]
+    "include": ["src", "src/**/*.json"],
+    "references": [{"path": "../intl-messageformat-parser"}]
 }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -30,4 +30,5 @@
         ]
     },
     "include": ["src/**/*.ts"],
+    "references": [{"path": "../babel-plugin-react-intl"}]
 }

--- a/packages/eslint-plugin-formatjs/tsconfig.json
+++ b/packages/eslint-plugin-formatjs/tsconfig.json
@@ -27,5 +27,6 @@
             "yargs"
         ]
     },
-    "include": ["src/**/*.ts"]
+    "include": ["src/**/*.ts"],
+    "references": [{"path": "../intl-messageformat-parser"}]
 }

--- a/packages/formatjs-extract-cldr-data/package.json
+++ b/packages/formatjs-extract-cldr-data/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "clean": "rimraf dist",
+    "clean": "rimraf dist *.tsbuildinfo",
     "test": "cross-env TS_NODE_PROJECT=./tsconfig.json cross-env NODE_ENV=test jest --maxWorkers=100%",
     "verify": "ts-node scripts/verify-numbers",
     "cover": "npm t -- --coverage"

--- a/packages/formatjs-extract-cldr-data/tsconfig.json
+++ b/packages/formatjs-extract-cldr-data/tsconfig.json
@@ -24,5 +24,6 @@
             "yargs"
         ]
     },
-    "include": ["src"]
+    "include": ["src"],
+    "references": [{"path": "../intl-utils"}]
 }

--- a/packages/intl-displaynames/tsconfig.json
+++ b/packages/intl-displaynames/tsconfig.json
@@ -28,4 +28,5 @@
       ]
   },
   "include": ["src/**/*.ts"],
+  "references": [{"path": "../formatjs-extract-cldr-data"}, {"path": "../intl-utils"}]
 }

--- a/packages/intl-format-cache/tsconfig.json
+++ b/packages/intl-format-cache/tsconfig.json
@@ -4,5 +4,6 @@
         "outDir": "dist",
         "rootDir": "src",
     },
-    "include": ["src"]
+    "include": ["src"],
+    "references": [{"path": "../intl-pluralrules"}, {"path": "../intl-relativetimeformat"}]
 }

--- a/packages/intl-listformat/tsconfig.json
+++ b/packages/intl-listformat/tsconfig.json
@@ -25,5 +25,6 @@
             "yargs"
         ],
     },
-    "include": ["src"]
+    "include": ["src"],
+    "references": [{"path": "../formatjs-extract-cldr-data"}, {"path": "../intl-utils"}]
 }

--- a/packages/intl-messageformat-parser/tsconfig.json
+++ b/packages/intl-messageformat-parser/tsconfig.json
@@ -24,5 +24,6 @@
             "yargs"
         ]
     },
-    "include": ["src"]
+    "include": ["src"],
+    "references": [{"path": "../intl-unified-numberformat"}]
 }

--- a/packages/intl-messageformat/tsconfig.json
+++ b/packages/intl-messageformat/tsconfig.json
@@ -1,8 +1,13 @@
 {
-    "extends": "../../tsconfig.json",
-    "compilerOptions": {
-        "outDir": "dist",
-        "rootDir": "src"
-    },
-    "include": ["src"]
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "references": [
+    {"path": "../intl-pluralrules"},
+    {"path": "../intl-format-cache"},
+    {"path": "../intl-messageformat-parser"}
+  ]
 }

--- a/packages/intl-pluralrules/tsconfig.json
+++ b/packages/intl-pluralrules/tsconfig.json
@@ -25,5 +25,6 @@
             "yargs"
         ]
     },
-    "include": ["src"]
+    "include": ["src"],
+    "references": [{"path": "../formatjs-extract-cldr-data"}, {"path": "../intl-utils"}]
 }

--- a/packages/intl-relativetimeformat/tsconfig.json
+++ b/packages/intl-relativetimeformat/tsconfig.json
@@ -1,30 +1,35 @@
 {
-    "extends": "../../tsconfig.json",
-    "compilerOptions": {
-        "lib": ["dom", "es5", "esnext.intl", "es2017.intl", "es2018.intl"],
-        "outDir": "dist",
-        "rootDir": "src",
-        "downlevelIteration": true,
-        "types": [
-            "babel__core",
-            "babel__generator",
-            "babel__template",
-            "babel__traverse",
-            "benchmark",
-            "chai",
-            "estree",
-            "fs-extra",
-            "istanbul-lib-coverage",
-            "istanbul-lib-report",
-            "istanbul-reports",
-            // Don't include mocha here
-            "jest",
-            "jest-diff",
-            "node",
-            "resolve",
-            "stack-utils",
-            "yargs"
-        ]
-    },
-    "include": ["src"]
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "lib": ["dom", "es5", "esnext.intl", "es2017.intl", "es2018.intl"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "downlevelIteration": true,
+    "types": [
+      "babel__core",
+      "babel__generator",
+      "babel__template",
+      "babel__traverse",
+      "benchmark",
+      "chai",
+      "estree",
+      "fs-extra",
+      "istanbul-lib-coverage",
+      "istanbul-lib-report",
+      "istanbul-reports",
+      // Don't include mocha here
+      "jest",
+      "jest-diff",
+      "node",
+      "resolve",
+      "stack-utils",
+      "yargs"
+    ]
+  },
+  "include": ["src"],
+  "references": [
+    {"path": "../intl-pluralrules"},
+    {"path": "../formatjs-extract-cldr-data"},
+    {"path": "../intl-utils"}
+  ]
 }

--- a/packages/intl-unified-numberformat/tsconfig.json
+++ b/packages/intl-unified-numberformat/tsconfig.json
@@ -27,5 +27,10 @@
             "yargs"
         ]
     },
-    "include": ["src"]
+    "include": ["src", "src/**/*.json"],
+    "references": [
+        {"path": "../intl-pluralrules"},
+        {"path": "../formatjs-extract-cldr-data"},
+        {"path": "../intl-utils"},
+    ]
 }

--- a/tests/ensure_build_output_structure.test.ts
+++ b/tests/ensure_build_output_structure.test.ts
@@ -2,9 +2,9 @@
  * Tests to ensure that `dist` or `lib` mirrors the source file tree.
  */
 
-import path from 'path';
+import {existsSync, readdirSync, readJsonSync} from 'fs-extra';
 import glob from 'glob';
-import {readJsonSync, readdir, existsSync, readdirSync} from 'fs-extra';
+import path from 'path';
 
 const PACKAGES_DIR = path.resolve(__dirname, '../packages');
 

--- a/tests/ensure_ts_project_reference_in_sync.test.ts
+++ b/tests/ensure_ts_project_reference_in_sync.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Ensure that project references in tsconfig.json of packages is in sync with Yarn workspace dependencies.
+ */
+
+import * as ts from 'typescript';
+import path from 'path';
+import {execSync} from 'child_process';
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const workspaceInfo = JSON.parse(
+  execSync('yarn -s workspaces info').toString()
+);
+
+for (const workspaceName of Object.keys(workspaceInfo)) {
+  const {location, workspaceDependencies} = workspaceInfo[workspaceName];
+  const packageLocation = path.resolve(REPO_ROOT, location);
+  const tsConfig = path.resolve(packageLocation, 'tsconfig.json');
+
+  test(`${workspaceName}: tsconfig.json project reference is in sync with \`yarn workspaces info\``, () => {
+    const tsconfigData = ts.readConfigFile(tsConfig, ts.sys.readFile).config;
+    expect(tsconfigData).toBeDefined();
+
+    if (workspaceDependencies.length === 0) {
+      expect(tsconfigData.references || []).toEqual([]);
+    } else {
+      const expectedReferences = workspaceDependencies.map(
+        (depWorkspaceName: string) => {
+          const depLocation = workspaceInfo[depWorkspaceName].location;
+          const depFolderName = path.basename(depLocation);
+          return {path: `../${depFolderName}`};
+        }
+      );
+      expect(tsconfigData.references).toHaveLength(expectedReferences.length);
+      expect(tsconfigData.references).toEqual(
+        expect.arrayContaining(expectedReferences)
+      );
+    }
+  });
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
         "preserveConstEnums": true,
         "declarationMap": true,
         "sourceMap": true,
+        "composite": true,
         "types": [
             "babel__core",
             "babel__generator",


### PR DESCRIPTION
This PR introduces 2 new yarn scripts to aid development:

```shell
# Build CommonJS of all packages
yarn build:cjs
# Watch mode for all packages
yarn dev:cjs
```

These 2 command will build all packages to CommonJS dist incrementally with TypeScript's build mode. They are especially useful if you are developing several packages together. And thanks to the incremental build mode, the rebuild on file change is almost instant.

Note that they do not replace the current build scripts! A full build via `yarn build` is still required before you can use these commands, to generate code via scripts (which may has dependency on other fully-built packages) and to make unit tests working. Moreover, these commands do not produce ES module build nor script-populated locale data.